### PR TITLE
No Refill Field trigger (closes #6)

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -1,9 +1,0 @@
-# -- Entity and Trigger Tooltips -- 
-#    placements.entities.entityName.tooltips.attr=Tooltip
-#    placements.triggers.triggerName.tooltips.attr=Tooltip
-
-# --- Triggers ---
-
-# No Refill Field
-
-placements.triggers.SpringCollab2020/NoRefillField.tooltips.noGroundRefillInside=If checked, ground refills will be disabled inside the field, and enabled outside. If unchecked, the contrary will happen.

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -4,6 +4,6 @@
 
 # --- Triggers ---
 
-# Factory Activation Trigger
+# No Refill Field
 
 placements.triggers.SpringCollab2020/NoRefillField.tooltips.noGroundRefillInside=If checked, ground refills will be disabled inside the field, and enabled outside. If unchecked, the contrary will happen.

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -1,0 +1,9 @@
+# -- Entity and Trigger Tooltips -- 
+#    placements.entities.entityName.tooltips.attr=Tooltip
+#    placements.triggers.triggerName.tooltips.attr=Tooltip
+
+# --- Triggers ---
+
+# Factory Activation Trigger
+
+placements.triggers.SpringCollab2020/NoRefillField.tooltips.noGroundRefillInside=If checked, ground refills will be disabled inside the field, and enabled outside. If unchecked, the contrary will happen.

--- a/Ahorn/triggers/noRefillField.jl
+++ b/Ahorn/triggers/noRefillField.jl
@@ -2,10 +2,10 @@ module SpringCollab2020NoRefillField
 
 using ..Ahorn, Maple
 
-@mapdef Trigger "SpringCollab2020/NoRefillField" NoRefillField(x::Integer, y::Integer, width::Integer=16, height::Integer=16)
+@mapdef Trigger "SpringCollab2020/NoRefillField" NoRefillField(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight)
 
 const placements = Ahorn.PlacementDict(
-    "No Refill Field (SpringCollab2020)" => Ahorn.EntityPlacement(
+    "No Refill Field (Spring Collab 2020)" => Ahorn.EntityPlacement(
         NoRefillField,
         "rectangle",
     ),

--- a/Ahorn/triggers/noRefillField.jl
+++ b/Ahorn/triggers/noRefillField.jl
@@ -1,0 +1,14 @@
+module SpringCollab2020NoRefillField
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/NoRefillField" NoRefillField(x::Integer, y::Integer, width::Integer=16, height::Integer=16, noGroundRefillInside::Bool=true)
+
+const placements = Ahorn.PlacementDict(
+    "No Refill Field (SpringCollab2020)" => Ahorn.EntityPlacement(
+        NoRefillField,
+        "rectangle",
+    ),
+)
+
+end

--- a/Ahorn/triggers/noRefillField.jl
+++ b/Ahorn/triggers/noRefillField.jl
@@ -2,7 +2,7 @@ module SpringCollab2020NoRefillField
 
 using ..Ahorn, Maple
 
-@mapdef Trigger "SpringCollab2020/NoRefillField" NoRefillField(x::Integer, y::Integer, width::Integer=16, height::Integer=16, noGroundRefillInside::Bool=true)
+@mapdef Trigger "SpringCollab2020/NoRefillField" NoRefillField(x::Integer, y::Integer, width::Integer=16, height::Integer=16)
 
 const placements = Ahorn.PlacementDict(
     "No Refill Field (SpringCollab2020)" => Ahorn.EntityPlacement(

--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Celeste.Mod.SpringCollab2020.Triggers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,9 +15,21 @@ namespace Celeste.Mod.SpringCollab2020 {
         }
 
         public override void Load() {
+            Everest.Events.Level.OnExit += onLevelExit;
         }
 
         public override void Unload() {
+            Everest.Events.Level.OnExit -= onLevelExit;
+        }
+
+        private void onLevelExit(Level level, LevelExit exit, LevelExit.Mode mode, Session session, HiresSnow snow) {
+            if (mode == LevelExit.Mode.SaveAndQuit) {
+                // if saving in a No Refill Field, be sure to restore the refills.
+                Player player = level.Tracker.GetEntity<Player>();
+                if (player != null && player.CollideCheck<NoRefillField>()) {
+                    level.Session.Inventory.NoRefills = false;
+                }
+            }
         }
     }
 }

--- a/Triggers/NoRefillField.cs
+++ b/Triggers/NoRefillField.cs
@@ -1,0 +1,24 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+    // Heavily based off the NoRefillTrigger class from vanilla, except reversing the state again on leave.
+    [CustomEntity("SpringCollab2020/NoRefillField")]
+    class NoRefillField : Trigger {
+        public bool NoGroundRefillInside;
+
+        public NoRefillField(EntityData data, Vector2 offset): base(data, offset) {
+            NoGroundRefillInside = data.Bool("noGroundRefillInside");
+        }
+
+        public override void OnEnter(Player player) {
+            base.OnEnter(player);
+            SceneAs<Level>().Session.Inventory.NoRefills = NoGroundRefillInside;
+        }
+
+        public override void OnLeave(Player player) {
+            base.OnLeave(player);
+            SceneAs<Level>().Session.Inventory.NoRefills = !NoGroundRefillInside;
+        }
+    }
+}

--- a/Triggers/NoRefillField.cs
+++ b/Triggers/NoRefillField.cs
@@ -10,7 +10,7 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
         public NoRefillField(EntityData data, Vector2 offset): base(data, offset) { }
 
         public override void OnEnter(Player player) {
-            base.OnStay(player);
+            base.OnEnter(player);
             SceneAs<Level>().Session.Inventory.NoRefills = true;
         }
 

--- a/Triggers/NoRefillField.cs
+++ b/Triggers/NoRefillField.cs
@@ -18,7 +18,7 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
             base.OnLeave(player);
 
             // re-enable refills if not colliding with another no refill field.
-            if (!player.CollideCheck<NoRefillField>()) {
+            if (player.Dead || !player.CollideCheck<NoRefillField>()) {
                 SceneAs<Level>().Session.Inventory.NoRefills = false;
             }
         }

--- a/Triggers/NoRefillField.cs
+++ b/Triggers/NoRefillField.cs
@@ -1,24 +1,26 @@
 ﻿using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
+using Monocle;
 
 namespace Celeste.Mod.SpringCollab2020.Triggers {
-    // Heavily based off the NoRefillTrigger class from vanilla, except reversing the state again on leave.
+    // Heavily based off the NoRefillTrigger class from vanilla, except reverting the state on leave.
     [CustomEntity("SpringCollab2020/NoRefillField")]
+    [Tracked]
     class NoRefillField : Trigger {
-        public bool NoGroundRefillInside;
-
-        public NoRefillField(EntityData data, Vector2 offset): base(data, offset) {
-            NoGroundRefillInside = data.Bool("noGroundRefillInside");
-        }
+        public NoRefillField(EntityData data, Vector2 offset): base(data, offset) { }
 
         public override void OnEnter(Player player) {
-            base.OnEnter(player);
-            SceneAs<Level>().Session.Inventory.NoRefills = NoGroundRefillInside;
+            base.OnStay(player);
+            SceneAs<Level>().Session.Inventory.NoRefills = true;
         }
 
         public override void OnLeave(Player player) {
             base.OnLeave(player);
-            SceneAs<Level>().Session.Inventory.NoRefills = !NoGroundRefillInside;
+
+            // re-enable refills if not colliding with another no refill field.
+            if (!player.CollideCheck<NoRefillField>()) {
+                SceneAs<Level>().Session.Inventory.NoRefills = false;
+            }
         }
     }
 }


### PR DESCRIPTION
Entering the trigger turns `NoRefills` in inventory to true, and exiting it turns it back to false, giving the expected effect: killing ground refills while you are in the field's area.

Closes #6 