### PR TITLE
Update GitHub Actions autobuild workflow

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: Build using .NET Core
 
 on: [push]
 
@@ -15,3 +15,8 @@ jobs:
         dotnet-version: 2.2.108
     - name: Build with dotnet
       run: dotnet build --configuration Release
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: main
+        path: bin/Release/net452


### PR DESCRIPTION
Who decided that auto-deleting branches were a good idea with gh-actions and that the workflow editor can't create a branch without a PR ._.