### PR TITLE
Add Remove Light Source Trigger

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -28,7 +28,7 @@ placements.triggers.SpringCollab2020/SmoothCameraOffsetTrigger.tooltips.position
 placements.triggers.SpringCollab2020/SmoothCameraOffsetTrigger.tooltips.onlyOnce=If checked, the trigger will be disabled when the player first leaves it.
 
 # Remove Light Sources Trigger
-placements.triggers.SpringCollab2020/RemoveLightSourcesTrigger.tooltips.isPersistent=If checked, all light sources will stay disabled even after leaving the trigger.
+placements.triggers.SpringCollab2020/RemoveLightSourcesTrigger.tooltips.persistent=If checked, all light sources will stay disabled even after leaving the trigger.
 
 # Dash Spring
 placements.entities.SpringCollab2020/dashSpring.tooltips.playerCanUse=Determines whether the player is able to interact with the spring.

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -27,5 +27,8 @@ placements.triggers.SpringCollab2020/SmoothCameraOffsetTrigger.tooltips.offsetYT
 placements.triggers.SpringCollab2020/SmoothCameraOffsetTrigger.tooltips.positionMode=The fade direction.
 placements.triggers.SpringCollab2020/SmoothCameraOffsetTrigger.tooltips.onlyOnce=If checked, the trigger will be disabled when the player first leaves it.
 
+# Remove Light Sources Trigger
+placements.triggers.SpringCollab2020/RemoveLightSourcesTrigger.tooltips.isPersistent=If checked, all light sources will stay disabled even after leaving the trigger.
+
 # Dash Spring
 placements.entities.SpringCollab2020/dashSpring.tooltips.playerCanUse=Determines whether the player is able to interact with the spring.

--- a/Ahorn/triggers/removeLightSourcesTrigger.jl
+++ b/Ahorn/triggers/removeLightSourcesTrigger.jl
@@ -2,7 +2,7 @@
 
 using ..Ahorn, Maple
 
-@mapdef Trigger "SpringCollab2020/RemoveLightSourcesTrigger" RemoveLightSourcesTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight, isPersistent::Bool=true)
+@mapdef Trigger "SpringCollab2020/RemoveLightSourcesTrigger" RemoveLightSourcesTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight, persistent::Bool=true)
 
 const placements = Ahorn.PlacementDict(
     "Remove Light Sources (Spring Collab 2020)" => Ahorn.EntityPlacement(

--- a/Ahorn/triggers/removeLightSourcesTrigger.jl
+++ b/Ahorn/triggers/removeLightSourcesTrigger.jl
@@ -1,0 +1,14 @@
+﻿module SpringCollab2020RemoveLightSources
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/RemoveLightSourcesTrigger" RemoveLightSourcesTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight, isPersistent::Bool=true)
+
+const placements = Ahorn.PlacementDict(
+    "Remove Light Sources (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        RemoveLightSourcesTrigger,
+        "rectangle",
+    ),
+)
+
+end

--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -13,11 +13,13 @@ namespace Celeste.Mod.SpringCollab2020 {
         public override void Load() {
             NoRefillField.Load();
             FloatierSpaceBlock.Load();
+            RemoveLightSourcesTrigger.Load();
         }
 
         public override void Unload() {
             NoRefillField.Unload();
             FloatierSpaceBlock.Unload();
+            RemoveLightSourcesTrigger.Unload();
         }
     }
 }

--- a/Triggers/RemoveLightSourcesTrigger.cs
+++ b/Triggers/RemoveLightSourcesTrigger.cs
@@ -23,11 +23,10 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
         }
 
         private static void LevelLoadHandler(Level loadedLevel, Player.IntroTypes playerIntro, bool isFromLoader) {
-            if(loadedLevel.Session.GetFlag("lightsDisabled") == true)
+            if(loadedLevel.Session.GetFlag("lightsDisabled") == true) {
                 DisableAllLights(loadedLevel);
-
-            if (loadedLevel.Session.GetFlag("lightsDisabled") == true)
                 On.Celeste.Level.TransitionTo += TransitionLightSources;
+            }
         }
 
         private static void OnExitHandler(Level exitLevel, LevelExit exit, LevelExit.Mode mode, Session session, HiresSnow snow) {

--- a/Triggers/RemoveLightSourcesTrigger.cs
+++ b/Triggers/RemoveLightSourcesTrigger.cs
@@ -1,0 +1,99 @@
+﻿using Celeste.Mod.Entities;
+using Monocle;
+using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+
+    [CustomEntity("SpringCollab2020/RemoveLightSourcesTrigger")]
+    [Tracked]
+    class RemoveLightSourcesTrigger : Trigger {
+        public RemoveLightSourcesTrigger(EntityData data, Vector2 offset) : base(data, offset) {
+            IsPersistent = data.Bool("isPersistent", true);
+            level = SceneAs<Level>();
+        }
+
+        public static void Load() {
+            Everest.Events.Level.OnLoadLevel += LevelLoadHandler;
+            Everest.Events.Level.OnExit += OnExitHandler;
+        }
+
+        public static void Unload() {
+            Everest.Events.Level.OnLoadLevel -= LevelLoadHandler;
+            Everest.Events.Level.OnExit -= OnExitHandler;
+        }
+
+        private static void LevelLoadHandler(Level loadedLevel, Player.IntroTypes playerIntro, bool isFromLoader) {
+            if(loadedLevel.Session.GetFlag("lightsDisabled") == true)
+                DisableAllLights(loadedLevel);
+
+            if (loadedLevel.Session.GetFlag("lightsDisabled") == true)
+                On.Celeste.Level.TransitionTo += TransitionLightSources;
+        }
+
+        private static void OnExitHandler(Level exitLevel, LevelExit exit, LevelExit.Mode mode, Session session, HiresSnow snow) {
+            On.Celeste.Level.TransitionTo -= TransitionLightSources;
+        }
+
+        private static void TransitionLightSources(On.Celeste.Level.orig_TransitionTo orig, Level transitionLevel, LevelData next, Vector2 direction) {
+            lightSources = new List<Component>();
+            bloomSources = new List<Component>();
+
+            DisableAllLights(transitionLevel);
+            orig(transitionLevel, next, direction);
+        }
+
+        private static void DisableAllLights(Level disableLevel) {
+            EntityList entities = disableLevel.Entities;
+
+            foreach (Entity entity in entities) {
+                foreach (Component component in entity.Components.ToArray()) {
+                    if (component is VertexLight) {
+                        lightSources.Add(component);
+                        component.Visible = false;
+                    }
+
+                    if (component is BloomPoint) {
+                        bloomSources.Add(component);
+                        component.Visible = false;
+                    }
+                }
+            }
+        }
+
+        public override void OnEnter(Player player) {
+            base.OnEnter(player);
+
+            level = SceneAs<Level>();
+
+            if (IsPersistent && level.Session.GetFlag("lightsDisabled") == false)
+                On.Celeste.Level.TransitionTo += TransitionLightSources;
+
+            if (IsPersistent)
+                level.Session.SetFlag("lightsDisabled", true);
+
+            DisableAllLights(level);
+        }
+
+        public override void OnLeave(Player player) {
+            base.OnLeave(player);
+
+            if (IsPersistent || level.Session.GetFlag("lightsDisabled") == true)
+                return;
+
+            foreach (Component component in lightSources)
+                component.Visible = true;
+
+            foreach (Component component in bloomSources)
+                component.Visible = true;
+        }
+
+        private static List<Component> lightSources = new List<Component>();
+
+        private static List<Component> bloomSources = new List<Component>();
+
+        private Level level;
+
+        private bool IsPersistent = true;
+    }
+}

--- a/Triggers/RemoveLightSourcesTrigger.cs
+++ b/Triggers/RemoveLightSourcesTrigger.cs
@@ -8,7 +8,7 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
     [Tracked]
     class RemoveLightSourcesTrigger : Trigger {
         public RemoveLightSourcesTrigger(EntityData data, Vector2 offset) : base(data, offset) {
-            IsPersistent = data.Bool("persistent", true);
+            Persistent = data.Bool("persistent", true);
             level = SceneAs<Level>();
         }
 
@@ -64,10 +64,10 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
 
             level = SceneAs<Level>();
 
-            if (IsPersistent && level.Session.GetFlag("lightsDisabled") == false)
+            if (Persistent && level.Session.GetFlag("lightsDisabled") == false)
                 On.Celeste.Level.TransitionTo += TransitionLightSources;
 
-            if (IsPersistent)
+            if (Persistent)
                 level.Session.SetFlag("lightsDisabled", true);
 
             DisableAllLights(level);
@@ -76,7 +76,7 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
         public override void OnLeave(Player player) {
             base.OnLeave(player);
 
-            if (IsPersistent || level.Session.GetFlag("lightsDisabled") == true)
+            if (Persistent || level.Session.GetFlag("lightsDisabled") == true)
                 return;
 
             foreach (Component component in lightSources)
@@ -92,6 +92,6 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
 
         private Level level;
 
-        private bool IsPersistent = true;
+        private bool Persistent = true;
     }
 }

--- a/Triggers/RemoveLightSourcesTrigger.cs
+++ b/Triggers/RemoveLightSourcesTrigger.cs
@@ -23,7 +23,7 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
         }
 
         private static void LevelLoadHandler(Level loadedLevel, Player.IntroTypes playerIntro, bool isFromLoader) {
-            if(loadedLevel.Session.GetFlag("lightsDisabled") == true) {
+            if (loadedLevel.Session.GetFlag("lightsDisabled")) {
                 DisableAllLights(loadedLevel);
                 On.Celeste.Level.TransitionTo += TransitionLightSources;
             }

--- a/Triggers/RemoveLightSourcesTrigger.cs
+++ b/Triggers/RemoveLightSourcesTrigger.cs
@@ -4,7 +4,6 @@ using Microsoft.Xna.Framework;
 using System.Collections.Generic;
 
 namespace Celeste.Mod.SpringCollab2020.Triggers {
-
     [CustomEntity("SpringCollab2020/RemoveLightSourcesTrigger")]
     [Tracked]
     class RemoveLightSourcesTrigger : Trigger {

--- a/Triggers/RemoveLightSourcesTrigger.cs
+++ b/Triggers/RemoveLightSourcesTrigger.cs
@@ -8,7 +8,7 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
     [Tracked]
     class RemoveLightSourcesTrigger : Trigger {
         public RemoveLightSourcesTrigger(EntityData data, Vector2 offset) : base(data, offset) {
-            IsPersistent = data.Bool("isPersistent", true);
+            IsPersistent = data.Bool("persistent", true);
             level = SceneAs<Level>();
         }
 


### PR DESCRIPTION
When inside, deactivates all BloomPoints and LightVertexes in the current screen. Upon exiting, all become reactivated.

If it is marked as persistent, the lights will ALWAYS stay off  in every room in that level once the player goes inside of the trigger. (Including after Save and Quits and room transitions)

Code is a bit spaghetti though 😬 