### PR TITLE
Sideways jumpthrus

### DIFF
--- a/Ahorn/entities/sidewaysJumpThru.jl
+++ b/Ahorn/entities/sidewaysJumpThru.jl
@@ -3,18 +3,29 @@ module SpringCollab2020SidewaysJumpThru
 using ..Ahorn, Maple
 
 @mapdef Entity "SpringCollab2020/SidewaysJumpThru" SidewaysJumpThru(x::Integer, y::Integer, height::Integer=Maple.defaultBlockHeight, 
-	allowLeftToRight::Bool=true, texture::String="wood")
+    left::Bool=true, texture::String="wood")
 
 textures = ["wood", "dream", "temple", "templeB", "cliffside", "reflection", "core", "moon"]
-const placements = Ahorn.PlacementDict(
-    "Sideways Jump Through ($(uppercasefirst(texture))) (Spring Collab 2020)" => Ahorn.EntityPlacement(
+const placements = Ahorn.PlacementDict()
+
+for texture in textures
+	placements["Sideways Jump Through ($(uppercasefirst(texture)), Left) (Spring Collab 2020)"] = Ahorn.EntityPlacement(
         SidewaysJumpThru,
         "rectangle",
         Dict{String, Any}(
-            "texture" => texture
+            "texture" => texture,
+            "left" => true
         )
-    ) for texture in textures
-)
+    )
+    placements["Sideways Jump Through ($(uppercasefirst(texture)), Right) (Spring Collab 2020)"] = Ahorn.EntityPlacement(
+        SidewaysJumpThru,
+        "rectangle",
+        Dict{String, Any}(
+            "texture" => texture,
+            "left" => false
+        )
+    )
+end
 
 quads = Tuple{Integer, Integer, Integer, Integer}[
     (0, 0, 8, 7) (8, 0, 8, 7) (16, 0, 8, 7);
@@ -44,8 +55,8 @@ function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::SidewaysJumpThru, r
     y = Int(get(entity.data, "y", 0))
 
     height = Int(get(entity.data, "height", 8))
-	allowLeftToRight = get(entity.data, "allowLeftToRight", true)
-	
+    left = get(entity.data, "left", true)
+    
     startX = div(x, 8) + 1
     startY = div(y, 8) + 1
     stopY = startY + div(height, 8) - 1
@@ -53,10 +64,10 @@ function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::SidewaysJumpThru, r
     Ahorn.Cairo.save(ctx)
     
     Ahorn.rotate(ctx, pi / 2)
-	
-	if !allowLeftToRight
-		Ahorn.scale(ctx, 1, -1)
-	end
+    
+    if left
+        Ahorn.scale(ctx, 1, -1)
+    end
 
     len = stopY - startY
     for i in 0:len
@@ -72,7 +83,7 @@ function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::SidewaysJumpThru, r
         end
 
         quad = quads[2 - connected, qx]
-        Ahorn.drawImage(ctx, "objects/jumpthru/$(texture)", 8 * i, allowLeftToRight ? -8 : 0, quad...)
+        Ahorn.drawImage(ctx, "objects/jumpthru/$(texture)", 8 * i, left ? 0 : -8, quad...)
     end
     
     Ahorn.Cairo.restore(ctx)

--- a/Ahorn/entities/sidewaysJumpThru.jl
+++ b/Ahorn/entities/sidewaysJumpThru.jl
@@ -1,0 +1,81 @@
+module SpringCollab2020SidewaysJumpThru
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/SidewaysJumpThru" SidewaysJumpThru(x::Integer, y::Integer, height::Integer=Maple.defaultBlockHeight, 
+	allowLeftToRight::Bool=true, texture::String="wood")
+
+textures = ["wood", "dream", "temple", "templeB", "cliffside", "reflection", "core", "moon"]
+const placements = Ahorn.PlacementDict(
+    "Sideways Jump Through ($(uppercasefirst(texture))) (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        SidewaysJumpThru,
+        "rectangle",
+        Dict{String, Any}(
+            "texture" => texture
+        )
+    ) for texture in textures
+)
+
+quads = Tuple{Integer, Integer, Integer, Integer}[
+    (0, 0, 8, 7) (8, 0, 8, 7) (16, 0, 8, 7);
+    (0, 8, 8, 5) (8, 8, 8, 5) (16, 8, 8, 5)
+]
+
+Ahorn.editingOptions(entity::SidewaysJumpThru) = Dict{String, Any}(
+    "texture" => textures
+)
+
+Ahorn.minimumSize(entity::SidewaysJumpThru) = 0, 8
+Ahorn.resizable(entity::SidewaysJumpThru) = false, true
+
+function Ahorn.selection(entity::SidewaysJumpThru)
+    x, y = Ahorn.position(entity)
+    height = Int(get(entity.data, "height", 8))
+
+    return Ahorn.Rectangle(x, y, 8, height)
+end
+
+function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::SidewaysJumpThru, room::Maple.Room)
+    texture = get(entity.data, "texture", "wood")
+    texture = texture == "default" ? "wood" : texture
+
+    # Values need to be system specific integer
+    x = Int(get(entity.data, "x", 0))
+    y = Int(get(entity.data, "y", 0))
+
+    height = Int(get(entity.data, "height", 8))
+	allowLeftToRight = get(entity.data, "allowLeftToRight", true)
+	
+    startX = div(x, 8) + 1
+    startY = div(y, 8) + 1
+    stopY = startY + div(height, 8) - 1
+    
+    Ahorn.Cairo.save(ctx)
+    
+    Ahorn.rotate(ctx, pi / 2)
+	
+	if !allowLeftToRight
+		Ahorn.scale(ctx, 1, -1)
+	end
+
+    len = stopY - startY
+    for i in 0:len
+        connected = false
+        qx = 2
+        if i == 0
+            connected = get(room.fgTiles.data, (startY - 1, startX), false) != '0'
+            qx = 1
+
+        elseif i == len
+            connected = get(room.fgTiles.data, (stopY + 1, startX), false) != '0'
+            qx = 3
+        end
+
+        quad = quads[2 - connected, qx]
+        Ahorn.drawImage(ctx, "objects/jumpthru/$(texture)", 8 * i, allowLeftToRight ? -8 : 0, quad...)
+    end
+    
+    Ahorn.Cairo.restore(ctx)
+end
+
+end

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -41,3 +41,10 @@ placements.entities.SpringCollab2020/dashSpring.tooltips.playerCanUse=Determines
 # Customizable Glass Block Controller
 placements.entities.SpringCollab2020/CustomizableGlassBlockController.tooltips.starColors=A comma-separated list of all star colours visible in glass blocks in the room.
 placements.entities.SpringCollab2020/CustomizableGlassBlockController.tooltips.bgColor=The background colour for glass blocks in the room.
+
+# Upside Down Jump Thru
+placements.entities.SpringCollab2020/UpsideDownJumpThru.tooltips.texture=Changes the appearance of the platform.
+
+# Sideways Jump Thru
+placements.entities.SpringCollab2020/SidewaysJumpThru.tooltips.texture=Changes the appearance of the platform.
+placements.entities.SpringCollab2020/SidewaysJumpThru.tooltips.allowLeftToRight=Changes the orientation of the platform. If checked, it will allow the player to go from left to right.

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -47,4 +47,4 @@ placements.entities.SpringCollab2020/UpsideDownJumpThru.tooltips.texture=Changes
 
 # Sideways Jump Thru
 placements.entities.SpringCollab2020/SidewaysJumpThru.tooltips.texture=Changes the appearance of the platform.
-placements.entities.SpringCollab2020/SidewaysJumpThru.tooltips.allowLeftToRight=Changes the orientation of the platform. If checked, it will allow the player to go from left to right.
+placements.entities.SpringCollab2020/SidewaysJumpThru.tooltips.left=Whether the solid side of the jumpthru is the left side.

--- a/Entities/SidewaysJumpThru.cs
+++ b/Entities/SidewaysJumpThru.cs
@@ -1,0 +1,285 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Monocle;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+using System;
+using System.Reflection;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    [CustomEntity("SpringCollab2020/SidewaysJumpThru")]
+    [Tracked]
+    class SidewaysJumpThru : Entity {
+
+        private static FieldInfo actorMovementCounter = typeof(Actor).GetField("movementCounter", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        public static void Load() {
+            // implement the basic collision between actors/platforms and sideways jumpthrus.
+            using (new DetourContext { Before = { "*" } }) { // these don't always call the orig methods, better apply them first.
+                On.Celeste.Actor.MoveHExact += onActorMoveHExact;
+                On.Celeste.Platform.MoveHExactCollideSolids += onPlatformMoveHExactCollideSolids;
+            }
+
+            // block "climb hopping" on top of sideways jumpthrus, because this just looks weird.
+            On.Celeste.Player.ClimbHopBlockedCheck += onPlayerClimbHopBlockedCheck;
+
+            // mod collide checks to include sideways jumpthrus, so that the player behaves with them like with walls.
+            IL.Celeste.Player.WallJumpCheck += modCollideChecks; // allow player to walljump off them
+            IL.Celeste.Player.ClimbCheck += modCollideChecks; // allow player to climb on them
+            IL.Celeste.Player.ClimbBegin += modCollideChecks; // if not applied, the player will clip through jumpthrus if trying to climb on them
+            IL.Celeste.Player.ClimbUpdate += modCollideChecks; // when climbing, jumpthrus are handled like walls
+            IL.Celeste.Player.SlipCheck += modCollideChecks; // make climbing on jumpthrus not slippery
+            IL.Celeste.Player.UpdateSprite += modCollideChecks; // have the push animation when Madeline runs against a jumpthru for example
+            IL.Celeste.Player.NormalUpdate += modCollideChecks; // get the wall slide effect
+            IL.Celeste.Player.OnCollideH += modCollideChecks; // handle dashes against jumpthrus properly, without "shifting" down
+
+            // one extra hook that kills the player momentum when hitting a jumpthru so that they don't get "stuck" on them.
+            On.Celeste.Player.NormalUpdate += onPlayerNormalUpdate;
+        }
+
+        public static void Unload() {
+            On.Celeste.Actor.MoveHExact -= onActorMoveHExact;
+            On.Celeste.Platform.MoveHExactCollideSolids -= onPlatformMoveHExactCollideSolids;
+
+            On.Celeste.Player.ClimbHopBlockedCheck -= onPlayerClimbHopBlockedCheck;
+
+            IL.Celeste.Player.WallJumpCheck -= modCollideChecks;
+            IL.Celeste.Player.ClimbCheck -= modCollideChecks;
+            IL.Celeste.Player.ClimbBegin -= modCollideChecks;
+            IL.Celeste.Player.ClimbUpdate -= modCollideChecks;
+            IL.Celeste.Player.SlipCheck -= modCollideChecks;
+            IL.Celeste.Player.UpdateSprite -= modCollideChecks;
+            IL.Celeste.Player.NormalUpdate -= modCollideChecks;
+            IL.Celeste.Player.OnCollideH -= modCollideChecks;
+
+            On.Celeste.Player.NormalUpdate -= onPlayerNormalUpdate;
+        }
+
+        private static bool onActorMoveHExact(On.Celeste.Actor.orig_MoveHExact orig, Actor self, int moveH, Collision onCollide, Solid pusher) {
+            // fall back to vanilla if no sideways jumpthru is in the room.
+            if (self.SceneAs<Level>().Tracker.CountEntities<SidewaysJumpThru>() == 0)
+                return orig(self, moveH, onCollide, pusher);
+
+            Vector2 targetPosition = self.Position + Vector2.UnitX * moveH;
+            int moveDirection = Math.Sign(moveH);
+            int moveAmount = 0;
+            bool movingLeftToRight = moveH > 0;
+            while (moveH != 0) {
+                bool didCollide = false;
+
+                // check if colliding with a solid
+                Solid solid = self.CollideFirst<Solid>(self.Position + Vector2.UnitX * moveDirection);
+                if (solid != null) {
+                    didCollide = true;
+                } else {
+                    // check if colliding with a sideways jumpthru
+                    SidewaysJumpThru jumpThru = self.CollideFirstOutside<SidewaysJumpThru>(self.Position + Vector2.UnitX * moveDirection);
+                    if (jumpThru != null && jumpThru.AllowLeftToRight != movingLeftToRight) {
+                        // there is a sideways jump-thru and we are moving in the opposite direction => collision
+                        didCollide = true;
+                    }
+                }
+
+                if (didCollide) {
+                    Vector2 movementCounter = (Vector2) actorMovementCounter.GetValue(self);
+                    movementCounter.X = 0f;
+                    onCollide?.Invoke(new CollisionData {
+                        Direction = Vector2.UnitX * moveDirection,
+                        Moved = Vector2.UnitX * moveAmount,
+                        TargetPosition = targetPosition,
+                        Hit = solid,
+                        Pusher = pusher
+                    });
+                    return true;
+                }
+
+                // continue moving
+                moveAmount += moveDirection;
+                moveH -= moveDirection;
+                self.X += moveDirection;
+            }
+            return false;
+        }
+
+        private static bool onPlatformMoveHExactCollideSolids(On.Celeste.Platform.orig_MoveHExactCollideSolids orig, Platform self,
+            int moveH, bool thruDashBlocks, Action<Vector2, Vector2, Platform> onCollide) {
+            // fall back to vanilla if no sideways jumpthru is in the room.
+            if (self.SceneAs<Level>().Tracker.CountEntities<SidewaysJumpThru>() == 0)
+                return orig(self, moveH, thruDashBlocks, onCollide);
+
+            float x = self.X;
+            int moveDirection = Math.Sign(moveH);
+            int moveAmount = 0;
+            Solid solid = null;
+            bool movingLeftToRight = moveH > 0;
+            bool collidedWithJumpthru = false;
+            while (moveH != 0) {
+                if (thruDashBlocks) {
+                    // check if we have dash blocks to break on our way.
+                    foreach (DashBlock entity in self.Scene.Tracker.GetEntities<DashBlock>()) {
+                        if (self.CollideCheck(entity, self.Position + Vector2.UnitX * moveDirection)) {
+                            entity.Break(self.Center, Vector2.UnitX * moveDirection, true, true);
+                            self.SceneAs<Level>().Shake(0.2f);
+                            Input.Rumble(RumbleStrength.Medium, RumbleLength.Medium);
+                        }
+                    }
+                }
+
+                // check for collision with a solid
+                solid = self.CollideFirst<Solid>(self.Position + Vector2.UnitX * moveDirection);
+
+                // check for collision with a sideways jumpthru
+                SidewaysJumpThru jumpThru = self.CollideFirstOutside<SidewaysJumpThru>(self.Position + Vector2.UnitX * moveDirection);
+                if (jumpThru != null && jumpThru.AllowLeftToRight != movingLeftToRight) {
+                    // there is a sideways jump-thru and we are moving in the opposite direction => collision
+                    collidedWithJumpthru = true;
+                }
+
+                if (solid != null || collidedWithJumpthru) {
+                    break;
+                }
+
+                // continue moving
+                moveAmount += moveDirection;
+                moveH -= moveDirection;
+                self.X += moveDirection;
+            }
+
+            // actually move and call the collision callback if any
+            self.X = x;
+            self.MoveHExact(moveAmount);
+            if (solid != null && onCollide != null) {
+                onCollide(Vector2.UnitX * moveDirection, Vector2.UnitX * moveAmount, solid);
+            }
+            return solid != null || collidedWithJumpthru;
+        }
+
+        private static bool onPlayerClimbHopBlockedCheck(On.Celeste.Player.orig_ClimbHopBlockedCheck orig, Player self) {
+            bool vanillaCheck = orig(self);
+            if (vanillaCheck)
+                return vanillaCheck;
+
+            // block climb hops on jumpthrus because those look weird
+            return self.CollideCheckOutside<SidewaysJumpThru>(self.Position + Vector2.UnitX * (int) self.Facing);
+        }
+
+        private static void modCollideChecks(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+
+            while (cursor.Next != null) {
+                Instruction next = cursor.Next;
+
+                // we want to replace all CollideChecks with solids here.
+                if (next.OpCode == OpCodes.Call && (next.Operand as MethodReference)?.FullName == "System.Boolean Monocle.Entity::CollideCheck<Celeste.Solid>(Microsoft.Xna.Framework.Vector2)") {
+                    Logger.Log("SpringCollab2020/SidewaysJumpThru", $"Patching Entity.CollideCheck to include sideways jumpthrus at {cursor.Index} in IL for {il.Method.Name}");
+
+                    cursor.Remove();
+                    cursor.EmitDelegate<Func<Entity, Vector2, bool>>((self, checkAtPosition) => {
+                        // we still want to check for solids...
+                        if (self.CollideCheck<Solid>(checkAtPosition))
+                            return true;
+
+                        // if we are not checking a side, this certainly has nothing to do with jumpthrus.
+                        if (self.Position.X == checkAtPosition.X)
+                            return false;
+
+                        // our entity also collides if this is with a jumpthru and we are colliding with the solid side of it.
+                        // we are in this case if the jumpthru is left to right (the "solid" side of it is the right one) 
+                        // and we are checking the collision on the left side of the player for example.
+                        bool collideOnLeftSideOfPlayer = (self.Position.X > checkAtPosition.X);
+                        SidewaysJumpThru jumpthru = self.CollideFirstOutside<SidewaysJumpThru>(checkAtPosition);
+                        return jumpthru != null && self is Player player && (jumpthru.AllowLeftToRight == collideOnLeftSideOfPlayer);
+                    });
+                }
+
+                if (next.OpCode == OpCodes.Callvirt && (next.Operand as MethodReference)?.FullName == "System.Boolean Monocle.Scene::CollideCheck<Celeste.Solid>(Microsoft.Xna.Framework.Vector2)") {
+                    Logger.Log("SpringCollab2020/SidewaysJumpThru", $"Patching Scene.CollideCheck to include sideways jumpthrus at {cursor.Index} in IL for {il.Method.Name}");
+
+                    cursor.Remove();
+                    cursor.EmitDelegate<Func<Scene, Vector2, bool>>((self, vector) => self.CollideCheck<Solid>(vector) || self.CollideCheck<SidewaysJumpThru>(vector));
+                }
+
+                cursor.Index++;
+            }
+        }
+
+        private static int onPlayerNormalUpdate(On.Celeste.Player.orig_NormalUpdate orig, Player self) {
+            int result = orig(self);
+
+            // kill speed if player is going towards a jumpthru.
+            if (self.Speed.X != 0) {
+                bool movingLeftToRight = self.Speed.X > 0;
+                SidewaysJumpThru jumpThru = self.CollideFirstOutside<SidewaysJumpThru>(self.Position + Vector2.UnitX * Math.Sign(self.Speed.X));
+                if (jumpThru != null && jumpThru.AllowLeftToRight != movingLeftToRight) {
+                    self.Speed.X = 0;
+                }
+            }
+
+            return result;
+        }
+
+
+
+
+        private int lines;
+        private string overrideTexture;
+
+        public bool AllowLeftToRight;
+
+        public SidewaysJumpThru(Vector2 position, int height, bool allowLeftToRight, string overrideTexture)
+            : base(position) {
+
+            lines = height / 8;
+            AllowLeftToRight = allowLeftToRight;
+            Depth = -60;
+            this.overrideTexture = overrideTexture;
+
+            float hitboxOffset = 0f;
+            if (AllowLeftToRight)
+                hitboxOffset = 3f;
+
+            Collider = new Hitbox(5f, height, hitboxOffset, 0);
+        }
+
+        public SidewaysJumpThru(EntityData data, Vector2 offset)
+            : this(data.Position + offset, data.Height, data.Bool("allowLeftToRight"), data.Attr("texture", "default")) {
+        }
+
+        public override void Awake(Scene scene) {
+            AreaData areaData = AreaData.Get(scene);
+            string jumpthru = areaData.Jumpthru;
+            if (!string.IsNullOrEmpty(overrideTexture) && !overrideTexture.Equals("default")) {
+                jumpthru = overrideTexture;
+            }
+
+            MTexture mTexture = GFX.Game["objects/jumpthru/" + jumpthru];
+            int num = mTexture.Width / 8;
+            for (int i = 0; i < lines; i++) {
+                int xTilePosition;
+                int yTilePosition;
+                if (i == 0) {
+                    xTilePosition = 0;
+                    yTilePosition = ((!CollideCheck<Solid>(Position + new Vector2(0f, -1f))) ? 1 : 0);
+                } else if (i == lines - 1) {
+                    xTilePosition = num - 1;
+                    yTilePosition = ((!CollideCheck<Solid>(Position + new Vector2(0f, 1f))) ? 1 : 0);
+                } else {
+                    xTilePosition = 1 + Calc.Random.Next(num - 2);
+                    yTilePosition = Calc.Random.Choose(0, 1);
+                }
+                Image image = new Image(mTexture.GetSubtexture(xTilePosition * 8, yTilePosition * 8, 8, 8));
+                image.Y = i * 8;
+                image.Rotation = (float) (Math.PI / 2);
+
+                if (AllowLeftToRight)
+                    image.X = 8;
+                else
+                    image.Scale.Y = -1;
+
+                Add(image);
+            }
+        }
+    }
+}

--- a/Entities/SidewaysJumpThru.cs
+++ b/Entities/SidewaysJumpThru.cs
@@ -220,8 +220,7 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             return result;
         }
 
-
-
+        // ======== Begin of entity code ========
 
         private int lines;
         private string overrideTexture;
@@ -244,7 +243,7 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
         }
 
         public SidewaysJumpThru(EntityData data, Vector2 offset)
-            : this(data.Position + offset, data.Height, data.Bool("allowLeftToRight"), data.Attr("texture", "default")) {
+            : this(data.Position + offset, data.Height, !data.Bool("left"), data.Attr("texture", "default")) {
         }
 
         public override void Awake(Scene scene) {

--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -16,6 +16,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             RemoveLightSourcesTrigger.Load();
             SafeRespawnCrumble.Load();
             UpsideDownJumpThru.Load();
+            SidewaysJumpThru.Load();
         }
 
         public override void Unload() {
@@ -24,6 +25,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             RemoveLightSourcesTrigger.Unload();
             SafeRespawnCrumble.Unload();
             UpsideDownJumpThru.Unload();
+            SidewaysJumpThru.Unload();
         }
     }
 }


### PR DESCRIPTION
Closes #20.

This time, I didn't make it extend JumpThru, since those have little in common (... the _orientation_ to begin with: jump thrus extend on their width).

Most of how it works is an IL patch applied on multiple methods, that adds collide checks against sideways jumpthrus everywhere the game checks for solids. This way, Madeline can climb on and walljump off sideways jumpthrus.

(Note to self: the Julia part seems to need a tab to space pass.)