### PR TITLE
Crystal Bomb (Cavern Helper) Detonation Field

### DIFF
--- a/Ahorn/entities/crystalBombDetonator.jl
+++ b/Ahorn/entities/crystalBombDetonator.jl
@@ -1,0 +1,33 @@
+﻿module SpringCollab2020CrystalBombDetonator
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/crystalBombDetonator" CrystalBombDetonator(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight)
+
+const placements = Ahorn.PlacementDict(
+    "Crystal Bomb Detonation Field (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        CrystalBombDetonator,
+        "rectangle"
+    ),
+)
+
+Ahorn.minimumSize(entity::CrystalBombDetonator) = 8, 8
+Ahorn.resizable(entity::CrystalBombDetonator) = true, true
+
+function Ahorn.selection(entity::CrystalBombDetonator)
+    x, y = Ahorn.position(entity)
+
+    width = Int(get(entity.data, "width", 8))
+    height = Int(get(entity.data, "height", 8))
+
+    return Ahorn.Rectangle(x, y, width, height)
+end
+
+function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::CrystalBombDetonator, room::Maple.Room)
+    width = Int(get(entity.data, "width", 32))
+    height = Int(get(entity.data, "height", 32))
+    
+    Ahorn.drawRectangle(ctx, 0, 0, width, height, (0.45, 0.0, 0.45, 0.8), (0.0, 0.0, 0.0, 0.0))
+end
+
+end

--- a/Entities/CrystalBombDetonator.cs
+++ b/Entities/CrystalBombDetonator.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    [Tracked(false)]
+    [CustomEntity("SpringCollab2020/crystalBombDetonator")]
+    public class CrystalBombDetonator : Solid {
+        public CrystalBombDetonator(Vector2 position, float width, float height) : base(position, width, height, false) {
+            Flash = 0f;
+            Solidify = 0f;
+            Flashing = false;
+            solidifyDelay = 0f;
+            particles = new List<Vector2>();
+            adjacent = new List<CrystalBombDetonator>();
+            speeds = new float[]
+            {
+                12f,
+                20f,
+                40f
+            };
+            Collidable = false;
+            int num = 0;
+            while ((float) num < Width * Height / 16f) {
+                particles.Add(new Vector2(Calc.Random.NextFloat(Width - 1f), Calc.Random.NextFloat(Height - 1f)));
+                num++;
+            }
+        }
+
+        public CrystalBombDetonator(EntityData data, Vector2 offset) : this(data.Position + offset, (float) data.Width, (float) data.Height) {
+        }
+
+        public override void Added(Scene scene) {
+            base.Added(scene);
+            scene.Tracker.GetEntity<CrystalBombDetonatorRenderer>().Track(this);
+        }
+
+        public override void Removed(Scene scene) {
+            base.Removed(scene);
+            scene.Tracker.GetEntity<CrystalBombDetonatorRenderer>().Untrack(this);
+        }
+
+        public override void Update() {
+            bool flashing = Flashing;
+            if (flashing) {
+                Flash = Calc.Approach(Flash, 0f, Engine.DeltaTime * 4f);
+                bool flag = Flash <= 0f;
+                if (flag) {
+                    Flashing = false;
+                }
+            } else {
+                bool flag2 = solidifyDelay > 0f;
+                if (flag2) {
+                    solidifyDelay -= Engine.DeltaTime;
+                } else {
+                    bool flag3 = Solidify > 0f;
+                    if (flag3) {
+                        Solidify = Calc.Approach(Solidify, 0f, Engine.DeltaTime);
+                    }
+                }
+            }
+            int num = speeds.Length;
+            float height = Height;
+            int i = 0;
+            int count = particles.Count;
+            while (i < count) {
+                Vector2 value = particles[i] + Vector2.UnitY * speeds[i % num] * Engine.DeltaTime;
+                value.Y %= height - 1f;
+                particles[i] = value;
+                i++;
+            }
+            base.Update();
+
+            CheckForBombs();
+        }
+
+        public void OnTriggerDetonation() {
+            Flash = 1f;
+            Solidify = 1f;
+            solidifyDelay = 1f;
+            Flashing = true;
+            Scene.CollideInto<CrystalBombDetonator>(new Rectangle((int) X, (int) Y - 2, (int) Width, (int) Height + 4), adjacent);
+            Scene.CollideInto<CrystalBombDetonator>(new Rectangle((int) X - 2, (int) Y, (int) Width + 4, (int) Height), adjacent);
+            foreach (CrystalBombDetonator crystalBombDetonator in adjacent) {
+                if(!crystalBombDetonator.Flashing)
+                    crystalBombDetonator.OnTriggerDetonation();
+            }
+            adjacent.Clear();
+        }
+
+        public override void Render() {
+            Color color = Color.Yellow * 0.6f;
+            foreach (Vector2 value in particles) {
+                Draw.Pixel.Draw(Position + value, Vector2.Zero, color);
+            }
+            if (Flashing)
+                Draw.Rect(Collider, Color.Purple * Flash * 0.5f);
+        }
+
+        private void CheckForBombs() {
+            foreach (Entity bomb in CollideAll<Actor>()) {
+                if (bomb.GetType().ToString().Contains("CrystalBomb")) {
+                    if (bombExplosionMethod == null)
+                        bombExplosionMethod = bomb.GetType().GetMethod("Explode", BindingFlags.Instance | BindingFlags.NonPublic);
+                    bombExplosionMethod.Invoke(bomb, null);
+                    if (!Flashing)
+                        OnTriggerDetonation();
+                }
+            }
+        }
+
+        public float Flash;
+        public float Solidify;
+        public bool Flashing;
+        private float solidifyDelay;
+        private List<Vector2> particles;
+        private List<CrystalBombDetonator> adjacent;
+        private float[] speeds;
+
+        private static MethodInfo bombExplosionMethod;
+    }
+}

--- a/Entities/CrystalBombDetonatorRenderer.cs
+++ b/Entities/CrystalBombDetonatorRenderer.cs
@@ -1,0 +1,269 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Monocle;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    [Tracked(false)]
+    public class CrystalBombDetonatorRenderer : Entity {
+        public CrystalBombDetonatorRenderer() {
+            list = new List<CrystalBombDetonator>();
+            edges = new List<CrystalBombDetonatorRenderer.Edge>();
+            Tag = (Tags.Global | Tags.TransitionUpdate);
+            Depth = 0;
+            Add(new CustomBloom(new Action(OnRenderBloom)));
+        }
+
+        public static void Load() {
+            On.Celeste.LevelLoader.LoadingThread += LevelLoader_LoadingThread;
+        }
+
+        public static void Unload() {
+            On.Celeste.LevelLoader.LoadingThread -= LevelLoader_LoadingThread;
+        }
+
+        static void LevelLoader_LoadingThread(On.Celeste.LevelLoader.orig_LoadingThread orig, LevelLoader self) {
+            self.Level.Add(new CrystalBombDetonatorRenderer());
+            orig(self);
+        }
+
+        public void Track(CrystalBombDetonator block) {
+            list.Add(block);
+            bool flag = tiles == null;
+            if (flag) {
+                levelTileBounds = (Scene as Level).TileBounds;
+                tiles = new VirtualMap<bool>(levelTileBounds.Width, levelTileBounds.Height, false);
+            }
+            int num = (int) block.X / 8;
+            while ((float) num < block.Right / 8f) {
+                int num2 = (int) block.Y / 8;
+                while ((float) num2 < block.Bottom / 8f) {
+                    tiles[num - levelTileBounds.X, num2 - levelTileBounds.Y] = true;
+                    num2++;
+                }
+                num++;
+            }
+            dirty = true;
+        }
+
+        public void Untrack(CrystalBombDetonator block) {
+            list.Remove(block);
+            bool flag = list.Count <= 0;
+            if (flag) {
+                tiles = null;
+            } else {
+                int num = (int) block.X / 8;
+                while ((float) num < block.Right / 8f) {
+                    int num2 = (int) block.Y / 8;
+                    while ((float) num2 < block.Bottom / 8f) {
+                        tiles[num - levelTileBounds.X, num2 - levelTileBounds.Y] = false;
+                        num2++;
+                    }
+                    num++;
+                }
+            }
+            dirty = true;
+        }
+
+        public override void Update() {
+            bool flag = dirty;
+            if (flag) {
+                RebuildEdges();
+            }
+            UpdateEdges();
+        }
+
+        public void UpdateEdges() {
+            Camera camera = (Scene as Level).Camera;
+            Rectangle rectangle = new Rectangle((int) camera.Left - 4, (int) camera.Top - 4, (int) (camera.Right - camera.Left) + 8, (int) (camera.Bottom - camera.Top) + 8);
+            for (int i = 0; i < edges.Count; i++) {
+                bool visible = edges[i].Visible;
+                if (visible) {
+                    bool flag = Scene.OnInterval(0.25f, (float) i * 0.01f) && !edges[i].InView(ref rectangle);
+                    if (flag) {
+                        edges[i].Visible = false;
+                    }
+                } else {
+                    bool flag2 = Scene.OnInterval(0.05f, (float) i * 0.01f) && edges[i].InView(ref rectangle);
+                    if (flag2) {
+                        edges[i].Visible = true;
+                    }
+                }
+                bool flag3 = edges[i].Visible && (Scene.OnInterval(0.05f, (float) i * 0.01f) || edges[i].Wave == null);
+                if (flag3) {
+                    edges[i].UpdateWave(Scene.TimeActive * 3f);
+                }
+            }
+        }
+
+        private void RebuildEdges() {
+            dirty = false;
+            edges.Clear();
+            bool flag = list.Count > 0;
+            if (flag) {
+                Level level = Scene as Level;
+                int left = level.TileBounds.Left;
+                int top = level.TileBounds.Top;
+                int right = level.TileBounds.Right;
+                int bottom = level.TileBounds.Bottom;
+                Point[] array = new Point[]
+                {
+                    new Point(0, -1),
+                    new Point(0, 1),
+                    new Point(-1, 0),
+                    new Point(1, 0)
+                };
+                foreach (CrystalBombDetonator crystalBombDetonator in list) {
+                    int num = (int) crystalBombDetonator.X / 8;
+                    while ((float) num < crystalBombDetonator.Right / 8f) {
+                        int num2 = (int) crystalBombDetonator.Y / 8;
+                        while ((float) num2 < crystalBombDetonator.Bottom / 8f) {
+                            foreach (Point point in array) {
+                                Point point2 = new Point(-point.Y, point.X);
+                                bool flag2 = !Inside(num + point.X, num2 + point.Y) && (!Inside(num - point2.X, num2 - point2.Y) || Inside(num + point.X - point2.X, num2 + point.Y - point2.Y));
+                                if (flag2) {
+                                    Point point3 = new Point(num, num2);
+                                    Point point4 = new Point(num + point2.X, num2 + point2.Y);
+                                    Vector2 value = new Vector2(4f) + new Vector2((float) (point.X - point2.X), (float) (point.Y - point2.Y)) * 4f;
+                                    while (Inside(point4.X, point4.Y) && !Inside(point4.X + point.X, point4.Y + point.Y)) {
+                                        point4.X += point2.X;
+                                        point4.Y += point2.Y;
+                                    }
+                                    Vector2 a = new Vector2((float) point3.X, (float) point3.Y) * 8f + value - crystalBombDetonator.Position;
+                                    Vector2 b = new Vector2((float) point4.X, (float) point4.Y) * 8f + value - crystalBombDetonator.Position;
+                                    edges.Add(new CrystalBombDetonatorRenderer.Edge(crystalBombDetonator, a, b));
+                                }
+                            }
+                            num2++;
+                        }
+                        num++;
+                    }
+                }
+            }
+        }
+
+        private bool Inside(int tx, int ty) {
+            return tiles[tx - levelTileBounds.X, ty - levelTileBounds.Y];
+        }
+
+        private void OnRenderBloom() {
+            Camera camera = (Scene as Level).Camera;
+            Rectangle rectangle = new Rectangle((int) camera.Left, (int) camera.Top, (int) (camera.Right - camera.Left), (int) (camera.Bottom - camera.Top));
+            foreach (CrystalBombDetonator crystalBombDetonator in list) {
+                bool flag = !crystalBombDetonator.Visible;
+                if (!flag) {
+                    Draw.Rect(crystalBombDetonator.X, crystalBombDetonator.Y, crystalBombDetonator.Width, crystalBombDetonator.Height, Color.Purple);
+                }
+            }
+            foreach (CrystalBombDetonatorRenderer.Edge edge in edges) {
+                bool flag2 = !edge.Visible;
+                if (!flag2) {
+                    Vector2 value = edge.Parent.Position + edge.A;
+                    Vector2 vector = edge.Parent.Position + edge.B;
+                    int num = 0;
+                    while ((float) num <= edge.Length) {
+                        Vector2 vector2 = value + edge.Normal * (float) num;
+                        Draw.Line(vector2, vector2 + edge.Perpendicular * edge.Wave[num], Color.Purple);
+                        num++;
+                    }
+                }
+            }
+        }
+
+        public override void Render() {
+            bool flag = list.Count <= 0;
+            if (!flag) {
+                Color color = Color.Purple * 0.45f;
+                Color value = Color.Purple * 0.55f;
+                foreach (CrystalBombDetonator crystalBombDetonator in list) {
+                    bool flag2 = !crystalBombDetonator.Visible;
+                    if (!flag2) {
+                        Draw.Rect(crystalBombDetonator.Collider, color);
+                    }
+                }
+                bool flag3 = edges.Count > 0;
+                if (flag3) {
+                    foreach (CrystalBombDetonatorRenderer.Edge edge in edges) {
+                        bool flag4 = !edge.Visible;
+                        if (!flag4) {
+                            Vector2 value2 = edge.Parent.Position + edge.A;
+                            Vector2 vector = edge.Parent.Position + edge.B;
+                            Color color2 = Color.Lerp(value, Color.Purple, edge.Parent.Flash);
+                            int num = 0;
+                            while ((float) num <= edge.Length) {
+                                Vector2 vector2 = value2 + edge.Normal * (float) num;
+                                Draw.Line(vector2, vector2 + edge.Perpendicular * edge.Wave[num], color);
+                                num++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private List<CrystalBombDetonator> list;
+        private List<CrystalBombDetonatorRenderer.Edge> edges;
+        private VirtualMap<bool> tiles;
+        private Rectangle levelTileBounds;
+        private bool dirty;
+
+        private class Edge {
+            public Edge(CrystalBombDetonator parent, Vector2 a, Vector2 b) {
+                Parent = parent;
+                Visible = true;
+                A = a;
+                B = b;
+                Min = new Vector2(Math.Min(a.X, b.X), Math.Min(a.Y, b.Y));
+                Max = new Vector2(Math.Max(a.X, b.X), Math.Max(a.Y, b.Y));
+                Normal = (b - a).SafeNormalize();
+                Perpendicular = -Normal.Perpendicular();
+                Length = (a - b).Length();
+            }
+
+            public void UpdateWave(float time) {
+                bool flag = Wave == null || (float) Wave.Length <= Length;
+                if (flag) {
+                    Wave = new float[(int) Length + 2];
+                }
+                int num = 0;
+                while ((float) num <= Length) {
+                    Wave[num] = GetWaveAt(time, (float) num, Length);
+                    num++;
+                }
+            }
+
+            private float GetWaveAt(float offset, float along, float length) {
+                bool flag = along <= 1f || along >= length - 1f;
+                float result;
+                if (flag) {
+                    result = 0f;
+                } else {
+                    bool flag2 = Parent.Solidify >= 1f;
+                    if (flag2) {
+                        result = 0f;
+                    } else {
+                        float num = offset + along * 0.25f;
+                        float num2 = (float) (Math.Sin((double) num) * 2.0 + Math.Sin((double) (num * 0.25f)));
+                        result = (1f + num2 * Ease.SineInOut(Calc.YoYo(along / length))) * (1f - Parent.Solidify);
+                    }
+                }
+                return result;
+            }
+
+            public bool InView(ref Rectangle view) {
+                return (float) view.Left < Parent.X + Max.X && (float) view.Right > Parent.X + Min.X && (float) view.Top < Parent.Y + Max.Y && (float) view.Bottom > Parent.Y + Min.Y;
+            }
+
+            public CrystalBombDetonator Parent;
+            public bool Visible;
+            public Vector2 A;
+            public Vector2 B;
+            public Vector2 Min;
+            public Vector2 Max;
+            public Vector2 Normal;
+            public Vector2 Perpendicular;
+            public float[] Wave;
+            public float Length;
+        }
+    }
+}

--- a/Entities/CrystalBombDetonatorRenderer.cs
+++ b/Entities/CrystalBombDetonatorRenderer.cs
@@ -6,14 +6,20 @@ using Monocle;
 namespace Celeste.Mod.SpringCollab2020.Entities {
     [Tracked(false)]
     public class CrystalBombDetonatorRenderer : Entity {
+
+        private List<CrystalBombDetonator> trackedFields = new List<CrystalBombDetonator>();
+        private List<CrystalBombDetonatorRenderer.Edge> fieldEdges = new List<CrystalBombDetonatorRenderer.Edge>();
+        private VirtualMap<bool> tiles;
+        private Rectangle levelTileBounds;
+        private bool dirty;
+
         public CrystalBombDetonatorRenderer() {
-            list = new List<CrystalBombDetonator>();
-            edges = new List<CrystalBombDetonatorRenderer.Edge>();
             Tag = (Tags.Global | Tags.TransitionUpdate);
             Depth = 0;
-            Add(new CustomBloom(new Action(OnRenderBloom)));
+            Add(new CustomBloom(OnRenderBloom));
         }
 
+        // Hooks to add ourself to the level at the very start
         public static void Load() {
             On.Celeste.LevelLoader.LoadingThread += LevelLoader_LoadingThread;
         }
@@ -27,80 +33,58 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             orig(self);
         }
 
+        // Add a field to the tracker
         public void Track(CrystalBombDetonator block) {
-            list.Add(block);
-            bool flag = tiles == null;
-            if (flag) {
+            trackedFields.Add(block);
+            if (tiles == null) {
                 levelTileBounds = (Scene as Level).TileBounds;
                 tiles = new VirtualMap<bool>(levelTileBounds.Width, levelTileBounds.Height, false);
             }
-            int num = (int) block.X / 8;
-            while ((float) num < block.Right / 8f) {
-                int num2 = (int) block.Y / 8;
-                while ((float) num2 < block.Bottom / 8f) {
-                    tiles[num - levelTileBounds.X, num2 - levelTileBounds.Y] = true;
-                    num2++;
-                }
-                num++;
-            }
+            
+            for (int xTile = (int)block.X / 8; xTile < (block.Right / 8f); xTile++)
+                for (int yTile = (int)block.Y / 8; yTile < (block.Bottom / 8f); yTile++)
+                    tiles[xTile - levelTileBounds.X, yTile - levelTileBounds.Y] = true;
+
             dirty = true;
         }
 
         public void Untrack(CrystalBombDetonator block) {
-            list.Remove(block);
-            bool flag = list.Count <= 0;
-            if (flag) {
+            trackedFields.Remove(block);
+            if (trackedFields.Count <= 0)
                 tiles = null;
-            } else {
-                int num = (int) block.X / 8;
-                while ((float) num < block.Right / 8f) {
-                    int num2 = (int) block.Y / 8;
-                    while ((float) num2 < block.Bottom / 8f) {
-                        tiles[num - levelTileBounds.X, num2 - levelTileBounds.Y] = false;
-                        num2++;
-                    }
-                    num++;
-                }
-            }
+            else
+                for (int xTile = (int)block.X / 8; xTile < (block.Right / 8f); xTile++)
+                    for (int yTile = (int)block.Y / 8; yTile < (block.Bottom / 8f); yTile++)
+                        tiles[xTile - levelTileBounds.X, yTile - levelTileBounds.Y] = false;
+
             dirty = true;
         }
 
         public override void Update() {
-            bool flag = dirty;
-            if (flag) {
+            if (dirty)
                 RebuildEdges();
-            }
             UpdateEdges();
         }
 
         public void UpdateEdges() {
             Camera camera = (Scene as Level).Camera;
-            Rectangle rectangle = new Rectangle((int) camera.Left - 4, (int) camera.Top - 4, (int) (camera.Right - camera.Left) + 8, (int) (camera.Bottom - camera.Top) + 8);
-            for (int i = 0; i < edges.Count; i++) {
-                bool visible = edges[i].Visible;
-                if (visible) {
-                    bool flag = Scene.OnInterval(0.25f, (float) i * 0.01f) && !edges[i].InView(ref rectangle);
-                    if (flag) {
-                        edges[i].Visible = false;
-                    }
-                } else {
-                    bool flag2 = Scene.OnInterval(0.05f, (float) i * 0.01f) && edges[i].InView(ref rectangle);
-                    if (flag2) {
-                        edges[i].Visible = true;
-                    }
-                }
-                bool flag3 = edges[i].Visible && (Scene.OnInterval(0.05f, (float) i * 0.01f) || edges[i].Wave == null);
-                if (flag3) {
-                    edges[i].UpdateWave(Scene.TimeActive * 3f);
-                }
+            Rectangle cameraRect = new Rectangle((int) camera.Left - 4, (int) camera.Top - 4, (int) (camera.Right - camera.Left) + 8, (int) (camera.Bottom - camera.Top) + 8);
+            for (int i = 0; i < fieldEdges.Count; i++) {
+                if (fieldEdges[i].Visible && Scene.OnInterval(0.25f, i * 0.01f) && !fieldEdges[i].InView(ref cameraRect))
+                    fieldEdges[i].Visible = false;
+                else
+                    if(Scene.OnInterval(0.05f, i * 0.01f) && fieldEdges[i].InView(ref cameraRect))
+                        fieldEdges[i].Visible = true;
+
+                if(fieldEdges[i].Visible && (Scene.OnInterval(0.05f, i * 0.01f) || fieldEdges[i].Wave == null))
+                    fieldEdges[i].UpdateWave(Scene.TimeActive * 3f);
             }
         }
 
         private void RebuildEdges() {
             dirty = false;
-            edges.Clear();
-            bool flag = list.Count > 0;
-            if (flag) {
+            fieldEdges.Clear();
+            if (trackedFields.Count > 0) {
                 Level level = Scene as Level;
                 int left = level.TileBounds.Left;
                 int top = level.TileBounds.Top;
@@ -113,17 +97,16 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
                     new Point(-1, 0),
                     new Point(1, 0)
                 };
-                foreach (CrystalBombDetonator crystalBombDetonator in list) {
-                    int num = (int) crystalBombDetonator.X / 8;
-                    while ((float) num < crystalBombDetonator.Right / 8f) {
-                        int num2 = (int) crystalBombDetonator.Y / 8;
-                        while ((float) num2 < crystalBombDetonator.Bottom / 8f) {
+
+                // personal note: I'm having trouble sorting out this code right now, what the hell is all of this and why are we using Points suddenly
+                foreach (CrystalBombDetonator crystalBombDetonator in trackedFields) {
+                    for (int xTile = (int) crystalBombDetonator.X / 8; xTile < (crystalBombDetonator.Right / 8f); xTile++)
+                        for (int yTile = (int) crystalBombDetonator.Y / 8; yTile < (crystalBombDetonator.Bottom / 8f); yTile++)
                             foreach (Point point in array) {
                                 Point point2 = new Point(-point.Y, point.X);
-                                bool flag2 = !Inside(num + point.X, num2 + point.Y) && (!Inside(num - point2.X, num2 - point2.Y) || Inside(num + point.X - point2.X, num2 + point.Y - point2.Y));
-                                if (flag2) {
-                                    Point point3 = new Point(num, num2);
-                                    Point point4 = new Point(num + point2.X, num2 + point2.Y);
+                                if (!Inside(xTile + point.X, yTile + point.Y) && (!Inside(xTile - point2.X, yTile - point2.Y) || Inside(xTile + point.X - point2.X, yTile + point.Y - point2.Y))) {
+                                    Point point3 = new Point(xTile, yTile);
+                                    Point point4 = new Point(xTile + point2.X, yTile + point2.Y);
                                     Vector2 value = new Vector2(4f) + new Vector2((float) (point.X - point2.X), (float) (point.Y - point2.Y)) * 4f;
                                     while (Inside(point4.X, point4.Y) && !Inside(point4.X + point.X, point4.Y + point.Y)) {
                                         point4.X += point2.X;
@@ -131,13 +114,9 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
                                     }
                                     Vector2 a = new Vector2((float) point3.X, (float) point3.Y) * 8f + value - crystalBombDetonator.Position;
                                     Vector2 b = new Vector2((float) point4.X, (float) point4.Y) * 8f + value - crystalBombDetonator.Position;
-                                    edges.Add(new CrystalBombDetonatorRenderer.Edge(crystalBombDetonator, a, b));
+                                    fieldEdges.Add(new CrystalBombDetonatorRenderer.Edge(crystalBombDetonator, a, b));
                                 }
                             }
-                            num2++;
-                        }
-                        num++;
-                    }
                 }
             }
         }
@@ -147,115 +126,49 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
         }
 
         private void OnRenderBloom() {
-            Camera camera = (Scene as Level).Camera;
-            Rectangle rectangle = new Rectangle((int) camera.Left, (int) camera.Top, (int) (camera.Right - camera.Left), (int) (camera.Bottom - camera.Top));
-            foreach (CrystalBombDetonator crystalBombDetonator in list) {
-                bool flag = !crystalBombDetonator.Visible;
-                if (!flag) {
+            foreach (CrystalBombDetonator crystalBombDetonator in trackedFields) {
+                if (crystalBombDetonator.Visible)
                     Draw.Rect(crystalBombDetonator.X, crystalBombDetonator.Y, crystalBombDetonator.Width, crystalBombDetonator.Height, Color.Purple);
-                }
             }
-            foreach (CrystalBombDetonatorRenderer.Edge edge in edges) {
-                bool flag2 = !edge.Visible;
-                if (!flag2) {
+            foreach (CrystalBombDetonatorRenderer.Edge edge in fieldEdges) {
+                if (edge.Visible) {
                     Vector2 value = edge.Parent.Position + edge.A;
                     Vector2 vector = edge.Parent.Position + edge.B;
-                    int num = 0;
-                    while ((float) num <= edge.Length) {
-                        Vector2 vector2 = value + edge.Normal * (float) num;
+                    for (int num = 0; num <= edge.Length; num++) {
+                        Vector2 vector2 = value + edge.Normal * num;
                         Draw.Line(vector2, vector2 + edge.Perpendicular * edge.Wave[num], Color.Purple);
-                        num++;
                     }
                 }
             }
         }
 
         public override void Render() {
-            bool flag = list.Count <= 0;
-            if (!flag) {
-                Color color = Color.Purple * 0.45f;
-                Color value = Color.Purple * 0.55f;
-                foreach (CrystalBombDetonator crystalBombDetonator in list) {
-                    bool flag2 = !crystalBombDetonator.Visible;
-                    if (!flag2) {
-                        Draw.Rect(crystalBombDetonator.Collider, color);
-                    }
-                }
-                bool flag3 = edges.Count > 0;
-                if (flag3) {
-                    foreach (CrystalBombDetonatorRenderer.Edge edge in edges) {
-                        bool flag4 = !edge.Visible;
-                        if (!flag4) {
-                            Vector2 value2 = edge.Parent.Position + edge.A;
-                            Vector2 vector = edge.Parent.Position + edge.B;
-                            Color color2 = Color.Lerp(value, Color.Purple, edge.Parent.Flash);
-                            int num = 0;
-                            while ((float) num <= edge.Length) {
-                                Vector2 vector2 = value2 + edge.Normal * (float) num;
-                                Draw.Line(vector2, vector2 + edge.Perpendicular * edge.Wave[num], color);
-                                num++;
-                            }
+            if (trackedFields.Count <= 0)
+                return;
+ 
+            Color color = Color.Purple * 0.45f;
+            Color value = Color.Purple * 0.55f;
+            foreach (CrystalBombDetonator crystalBombDetonator in trackedFields) {
+                if (crystalBombDetonator.Visible)
+                    Draw.Rect(crystalBombDetonator.Collider, color);
+            }
+            if (fieldEdges.Count > 0)
+                foreach (CrystalBombDetonatorRenderer.Edge edge in fieldEdges) {
+                    if (edge.Visible) {
+                        Vector2 value2 = edge.Parent.Position + edge.A;
+                        Vector2 vector = edge.Parent.Position + edge.B;
+                        Color color2 = Color.Lerp(value, Color.Purple, edge.Parent.Flash);
+                        for (int num = 0; num <= edge.Length; num++) {
+                            Vector2 vector2 = value2 + edge.Normal * num;
+                            Draw.Line(vector2, vector2 + edge.Perpendicular * edge.Wave[num], color);
                         }
                     }
                 }
-            }
         }
 
-        private List<CrystalBombDetonator> list;
-        private List<CrystalBombDetonatorRenderer.Edge> edges;
-        private VirtualMap<bool> tiles;
-        private Rectangle levelTileBounds;
-        private bool dirty;
-
         private class Edge {
-            public Edge(CrystalBombDetonator parent, Vector2 a, Vector2 b) {
-                Parent = parent;
-                Visible = true;
-                A = a;
-                B = b;
-                Min = new Vector2(Math.Min(a.X, b.X), Math.Min(a.Y, b.Y));
-                Max = new Vector2(Math.Max(a.X, b.X), Math.Max(a.Y, b.Y));
-                Normal = (b - a).SafeNormalize();
-                Perpendicular = -Normal.Perpendicular();
-                Length = (a - b).Length();
-            }
-
-            public void UpdateWave(float time) {
-                bool flag = Wave == null || (float) Wave.Length <= Length;
-                if (flag) {
-                    Wave = new float[(int) Length + 2];
-                }
-                int num = 0;
-                while ((float) num <= Length) {
-                    Wave[num] = GetWaveAt(time, (float) num, Length);
-                    num++;
-                }
-            }
-
-            private float GetWaveAt(float offset, float along, float length) {
-                bool flag = along <= 1f || along >= length - 1f;
-                float result;
-                if (flag) {
-                    result = 0f;
-                } else {
-                    bool flag2 = Parent.Solidify >= 1f;
-                    if (flag2) {
-                        result = 0f;
-                    } else {
-                        float num = offset + along * 0.25f;
-                        float num2 = (float) (Math.Sin((double) num) * 2.0 + Math.Sin((double) (num * 0.25f)));
-                        result = (1f + num2 * Ease.SineInOut(Calc.YoYo(along / length))) * (1f - Parent.Solidify);
-                    }
-                }
-                return result;
-            }
-
-            public bool InView(ref Rectangle view) {
-                return (float) view.Left < Parent.X + Max.X && (float) view.Right > Parent.X + Min.X && (float) view.Top < Parent.Y + Max.Y && (float) view.Bottom > Parent.Y + Min.Y;
-            }
-
             public CrystalBombDetonator Parent;
-            public bool Visible;
+            public bool Visible = true;
             public Vector2 A;
             public Vector2 B;
             public Vector2 Min;
@@ -264,6 +177,41 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             public Vector2 Perpendicular;
             public float[] Wave;
             public float Length;
+
+            public Edge(CrystalBombDetonator parent, Vector2 a, Vector2 b) {
+                Parent = parent;
+                A = a;
+                B = b;
+                Min = new Vector2(Math.Min(A.X, B.X), Math.Min(A.Y, B.Y));
+                Max = new Vector2(Math.Max(A.X, B.X), Math.Max(A.Y, B.Y));
+                Normal = (B - A).SafeNormalize();
+                Perpendicular = -Normal.Perpendicular();
+                Length = (A - B).Length();
+            }
+
+            public void UpdateWave(float time) {
+                if (Wave == null || (float) Wave.Length <= Length)
+                    Wave = new float[(int) Length + 2];
+
+                for (int num = 0; num <= Length; num++)
+                    Wave[num] = GetWaveAt(time, num, Length);
+            }
+
+            private float GetWaveAt(float offset, float along, float length) {
+                if (along <= 1f || along >= length - 1f)
+                    return 0f;
+
+                if (Parent.Solidify >= 1f)
+                    return 0f;
+                
+                float num = offset + along * 0.25f;
+                float num2 = (float) (Math.Sin((double) num) * 2.0 + Math.Sin((double) (num * 0.25f)));
+                return (1f + num2 * Ease.SineInOut(Calc.YoYo(along / length))) * (1f - Parent.Solidify);
+            }
+
+            public bool InView(ref Rectangle view) {
+                return (float) view.Left < Parent.X + Max.X && (float) view.Right > Parent.X + Min.X && (float) view.Top < Parent.Y + Max.Y && (float) view.Bottom > Parent.Y + Min.Y;
+            }
         }
     }
 }

--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -19,6 +19,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             SafeRespawnCrumble.Load();
             UpsideDownJumpThru.Load();
             SidewaysJumpThru.Load();
+            CrystalBombDetonatorRenderer.Load();
         }
 
         public override void LoadContent(bool firstLoad) {
@@ -36,6 +37,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             GlassBerry.Unload();
             UpsideDownJumpThru.Unload();
             SidewaysJumpThru.Unload();
+            CrystalBombDetonatorRenderer.Unload();
         }
     }
 }


### PR DESCRIPTION
A field to be placed as Seeker Barriers would, used for detonating Crystal Bombs thrown/carried into them much like they are used to destroy Jellyfish.

Closes #62.

It's a bit of a disgusting hack, but it works, dammit.