### PR TITLE
No dash refill spring

### DIFF
--- a/Ahorn/entities/noDashRefillSpring.jl
+++ b/Ahorn/entities/noDashRefillSpring.jl
@@ -1,4 +1,4 @@
-﻿module SpringCollab2020DashSpring
+﻿module SpringCollab2020NoDashRefillSpring
 
 using ..Ahorn, Maple
 

--- a/Ahorn/entities/noDashRefillSpring.jl
+++ b/Ahorn/entities/noDashRefillSpring.jl
@@ -1,0 +1,45 @@
+﻿module SpringCollab2020DashSpring
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/NoDashRefillSpring" NoDashRefillSpring(x::Integer, y::Integer, playerCanUse::Bool=true)
+@mapdef Entity "SpringCollab2020/NoDashRefillSpringRight" NoDashRefillSpringRight(x::Integer, y::Integer)
+@mapdef Entity "SpringCollab2020/NoDashRefillSpringLeft" NoDashRefillSpringLeft(x::Integer, y::Integer)
+
+const placements = Ahorn.PlacementDict(
+    "No Dash Refill Spring (Up) (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        NoDashRefillSpring
+    ),
+    "No Dash Refill Spring (Left) (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        NoDashRefillSpringRight
+    ),
+    "No Dash Refill Spring (Right) (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        NoDashRefillSpringLeft
+    ),
+)
+
+function Ahorn.selection(entity::NoDashRefillSpring)
+    x, y = Ahorn.position(entity)
+
+    return Ahorn.Rectangle(x - 6, y - 3, 12, 5)
+end
+
+function Ahorn.selection(entity::NoDashRefillSpringLeft)
+    x, y = Ahorn.position(entity)
+
+    return Ahorn.Rectangle(x - 1, y - 6, 5, 12)
+end
+
+function Ahorn.selection(entity::NoDashRefillSpringRight)
+    x, y = Ahorn.position(entity)
+
+    return Ahorn.Rectangle(x - 4, y - 6, 5, 12)
+end
+
+sprite = "objects/spring/00.png"
+
+Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::NoDashRefillSpring, room::Maple.Room) = Ahorn.drawSprite(ctx, sprite, 0, -8)
+Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::NoDashRefillSpringLeft, room::Maple.Room) = Ahorn.drawSprite(ctx, sprite, 9, -11, rot=pi / 2)
+Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::NoDashRefillSpringRight, room::Maple.Room) = Ahorn.drawSprite(ctx, sprite, 3, 1, rot=-pi / 2)
+
+end

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -109,3 +109,6 @@ placements.entities.SpringCollab2020/MoveBlockCustomSpeed.tooltips.moveSpeed=The
 
 # Disable Ice Physics Trigger
 placements.triggers.SpringCollab2020/DisableIcePhysicsTrigger.tooltips.disableIcePhysics=Check to disable ice physics when entering the trigger. Uncheck to enable them again.
+
+# No Dash Refill Spring
+placements.entities.SpringCollab2020/NoDashRefillSpring.tooltips.playerCanUse=Determines whether the player is able to interact with the spring.

--- a/Entities/NoDashRefillSpring.cs
+++ b/Entities/NoDashRefillSpring.cs
@@ -1,0 +1,77 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    [CustomEntity("SpringCollab2020/NoDashRefillSpring", "SpringCollab2020/NoDashRefillSpringLeft", "SpringCollab2020/NoDashRefillSpringRight")]
+    class NoDashRefillSpring : Spring {
+        private static MethodInfo bounceAnimate = typeof(Spring).GetMethod("BounceAnimate", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static object[] noParams = new object[0];
+
+        public NoDashRefillSpring(EntityData data, Vector2 offset)
+            : base(data.Position + offset, GetOrientationFromName(data.Name), data.Bool("playerCanUse", true)) {
+
+            // remove the vanilla player collider. this is the one thing we want to mod here.
+            foreach(Component component in this) {
+                if(component.GetType() == typeof(PlayerCollider)) {
+                    Remove(component);
+                    break;
+                }
+            }
+
+            // replace it with our own collider.
+            if(data.Bool("playerCanUse", true)) {
+                Add(new PlayerCollider(OnCollide));
+            }
+        }
+
+        private static Orientations GetOrientationFromName(string name) {
+            switch (name) {
+                case "SpringCollab2020/NoDashRefillSpring":
+                    return Orientations.Floor;
+                case "SpringCollab2020/NoDashRefillSpringRight":
+                    return Orientations.WallRight;
+                case "SpringCollab2020/NoDashRefillSpringLeft":
+                    return Orientations.WallLeft;
+                default:
+                    throw new Exception("No Dash Refill Spring name doesn't correlate to a valid Orientation!");
+            }
+        }
+
+
+        private void OnCollide(Player player) {
+            if (player.StateMachine.State == 9) {
+                return;
+            }
+
+            // Save dash count. Dashes are reloaded by SideBounce and SuperBounce.
+            int originalDashCount = player.Dashes;
+
+            if (Orientation == Orientations.Floor) {
+                if (player.Speed.Y >= 0f) {
+                    bounceAnimate.Invoke(this, noParams);
+                    player.SuperBounce(Top);
+                }
+            } else if (Orientation == Orientations.WallLeft) {
+                if (player.SideBounce(1, Right, CenterY)) {
+                    bounceAnimate.Invoke(this, noParams);
+                }
+            } else if (Orientation == Orientations.WallRight) {
+                if (player.SideBounce(-1, Left, CenterY)) {
+                    bounceAnimate.Invoke(this, noParams);
+                }
+            } else {
+                throw new Exception("Orientation not supported!");
+            }
+
+            // Restore original dash count.
+            player.Dashes = originalDashCount;
+        }
+    }
+}

--- a/Entities/NoDashRefillSpring.cs
+++ b/Entities/NoDashRefillSpring.cs
@@ -2,11 +2,7 @@
 using Microsoft.Xna.Framework;
 using Monocle;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Celeste.Mod.SpringCollab2020.Entities {
     [CustomEntity("SpringCollab2020/NoDashRefillSpring", "SpringCollab2020/NoDashRefillSpringLeft", "SpringCollab2020/NoDashRefillSpringRight")]
@@ -18,15 +14,15 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             : base(data.Position + offset, GetOrientationFromName(data.Name), data.Bool("playerCanUse", true)) {
 
             // remove the vanilla player collider. this is the one thing we want to mod here.
-            foreach(Component component in this) {
-                if(component.GetType() == typeof(PlayerCollider)) {
+            foreach (Component component in this) {
+                if (component.GetType() == typeof(PlayerCollider)) {
                     Remove(component);
                     break;
                 }
             }
 
             // replace it with our own collider.
-            if(data.Bool("playerCanUse", true)) {
+            if (data.Bool("playerCanUse", true)) {
                 Add(new PlayerCollider(OnCollide));
             }
         }


### PR DESCRIPTION
Closes #70.

This is just a spring that looks like a vanilla spring and acts like it, with the only difference being the player collider. This one ensures that your dash count is intact even after bouncing on the spring.