### PR TITLE
Grouped trigger spikes

### DIFF
--- a/Ahorn/entities/groupedTriggerSpikes.jl
+++ b/Ahorn/entities/groupedTriggerSpikes.jl
@@ -18,12 +18,6 @@ groupedTriggerSpikes = Dict{String, Type}(
 
 groupedTriggerSpikesUnion = Union{GroupedTriggerSpikesUp, GroupedTriggerSpikesDown, GroupedTriggerSpikesLeft, GroupedTriggerSpikesRight}
 
-triggerSpikeColors = [
-    (242, 90, 16, 255) ./ 255,
-    (255, 0, 0, 255) ./ 255,
-    (242, 16, 103, 255) ./ 255
-]
-
 for variant in Maple.spike_types
     if variant != "tentacles"
         for (dir, entity) in groupedTriggerSpikes
@@ -64,13 +58,6 @@ groupedTriggerSpikesOffsets = Dict{String, Tuple{Integer, Integer}}(
     "right" => (-4, 0),
 )
 
-groupedTriggerRotationOffsets = Dict{String, Tuple{Number, Number}}(
-    "up" => (3, -1),
-    "right" => (4, 3),
-    "down" => (5, 5),
-    "left" => (-1, 4),
-)
-
 rotations = Dict{String, Number}(
     "up" => 0,
     "right" => pi / 2,
@@ -106,10 +93,6 @@ function Ahorn.selection(entity::groupedTriggerSpikesUnion)
         height = Int(get(entity.data, "height", 8))
 
         direction = get(directions, entity.name, "up")
-        variant = get(entity.data, "type", "default")
-
-        width = Int(get(entity.data, "width", 8))
-        height = Int(get(entity.data, "height", 8))
 
         ox, oy = offsets[direction]
 
@@ -121,7 +104,6 @@ Ahorn.minimumSize(entity::groupedTriggerSpikesUnion) = 8, 8
 
 function Ahorn.resizable(entity::groupedTriggerSpikesUnion)
     if haskey(directions, entity.name)
-        variant = get(entity.data, "type", "default")
         direction = get(directions, entity.name, "up")
 
         return resizeDirections[direction]

--- a/Ahorn/entities/groupedTriggerSpikes.jl
+++ b/Ahorn/entities/groupedTriggerSpikes.jl
@@ -1,0 +1,147 @@
+module SpringCollab2020GroupedTriggerSpikes
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/GroupedTriggerSpikesUp" GroupedTriggerSpikesUp(x::Integer, y::Integer, width::Integer=Maple.defaultSpikeWidth, type::String="default")
+@mapdef Entity "SpringCollab2020/GroupedTriggerSpikesDown" GroupedTriggerSpikesDown(x::Integer, y::Integer, width::Integer=Maple.defaultSpikeWidth, type::String="default")
+@mapdef Entity "SpringCollab2020/GroupedTriggerSpikesLeft" GroupedTriggerSpikesLeft(x::Integer, y::Integer, height::Integer=Maple.defaultSpikeHeight, type::String="default")
+@mapdef Entity "SpringCollab2020/GroupedTriggerSpikesRight" GroupedTriggerSpikesRight(x::Integer, y::Integer, height::Integer=Maple.defaultSpikeHeight, type::String="default")
+
+const placements = Ahorn.PlacementDict()
+
+groupedTriggerSpikes = Dict{String, Type}(
+    "up" => GroupedTriggerSpikesUp,
+    "down" => GroupedTriggerSpikesDown,
+    "left" => GroupedTriggerSpikesLeft,
+    "right" => GroupedTriggerSpikesRight
+)
+
+groupedTriggerSpikesUnion = Union{GroupedTriggerSpikesUp, GroupedTriggerSpikesDown, GroupedTriggerSpikesLeft, GroupedTriggerSpikesRight}
+
+triggerSpikeColors = [
+    (242, 90, 16, 255) ./ 255,
+    (255, 0, 0, 255) ./ 255,
+    (242, 16, 103, 255) ./ 255
+]
+
+for variant in Maple.spike_types
+    if variant != "tentacles"
+        for (dir, entity) in groupedTriggerSpikes
+            key = "Grouped Trigger Spikes ($(uppercasefirst(dir)), $(uppercasefirst(variant))) (Spring Collab 2020)"
+            placements[key] = Ahorn.EntityPlacement(
+                entity,
+                "rectangle",
+                Dict{String, Any}(
+                    "type" => variant
+                )
+            )
+        end
+    end
+end
+
+Ahorn.editingOptions(entity::groupedTriggerSpikesUnion) = Dict{String, Any}(
+    "type" => String[variant for variant in Maple.spike_types if variant != "tentacles"]
+)
+
+directions = Dict{String, String}(
+    "SpringCollab2020/GroupedTriggerSpikesUp" => "up",
+    "SpringCollab2020/GroupedTriggerSpikesDown" => "down",
+    "SpringCollab2020/GroupedTriggerSpikesLeft" => "left",
+    "SpringCollab2020/GroupedTriggerSpikesRight" => "right",
+)
+
+offsets = Dict{String, Tuple{Integer, Integer}}(
+    "up" => (4, -4),
+    "down" => (4, 4),
+    "left" => (-4, 4),
+    "right" => (4, 4),
+)
+
+groupedTriggerSpikesOffsets = Dict{String, Tuple{Integer, Integer}}(
+    "up" => (0, 5),
+    "down" => (0, -4),
+    "left" => (5, 0),
+    "right" => (-4, 0),
+)
+
+groupedTriggerRotationOffsets = Dict{String, Tuple{Number, Number}}(
+    "up" => (3, -1),
+    "right" => (4, 3),
+    "down" => (5, 5),
+    "left" => (-1, 4),
+)
+
+rotations = Dict{String, Number}(
+    "up" => 0,
+    "right" => pi / 2,
+    "down" => pi,
+    "left" => pi * 3 / 2
+)
+
+resizeDirections = Dict{String, Tuple{Bool, Bool}}(
+    "up" => (true, false),
+    "down" => (true, false),
+    "left" => (false, true),
+    "right" => (false, true),
+)
+
+function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::groupedTriggerSpikesUnion)
+    direction = get(directions, entity.name, "up")
+    theta = rotations[direction] - pi / 2
+
+    width = Int(get(entity.data, "width", 0))
+    height = Int(get(entity.data, "height", 0))
+
+    x, y = Ahorn.position(entity)
+    cx, cy = x + floor(Int, width / 2) - 8 * (direction == "left"), y + floor(Int, height / 2) - 8 * (direction == "up")
+
+    Ahorn.drawArrow(ctx, cx, cy, cx + cos(theta) * 24, cy + sin(theta) * 24, Ahorn.colors.selection_selected_fc, headLength=6)
+end
+
+function Ahorn.selection(entity::groupedTriggerSpikesUnion)
+    if haskey(directions, entity.name)
+        x, y = Ahorn.position(entity)
+
+        width = Int(get(entity.data, "width", 8))
+        height = Int(get(entity.data, "height", 8))
+
+        direction = get(directions, entity.name, "up")
+        variant = get(entity.data, "type", "default")
+
+        width = Int(get(entity.data, "width", 8))
+        height = Int(get(entity.data, "height", 8))
+
+        ox, oy = offsets[direction]
+
+        return Ahorn.Rectangle(x + ox - 4, y + oy - 4, width, height)
+    end
+end
+
+Ahorn.minimumSize(entity::groupedTriggerSpikesUnion) = 8, 8
+
+function Ahorn.resizable(entity::groupedTriggerSpikesUnion)
+    if haskey(directions, entity.name)
+        variant = get(entity.data, "type", "default")
+        direction = get(directions, entity.name, "up")
+
+        return resizeDirections[direction]
+    end
+end
+
+function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::groupedTriggerSpikesUnion)
+    if haskey(directions, entity.name)
+        variant = get(entity.data, "type", "default")
+        direction = get(directions, entity.name, "up")
+        groupedTriggerSpikesOffset = groupedTriggerSpikesOffsets[direction]
+
+        width = get(entity.data, "width", 8)
+        height = get(entity.data, "height", 8)
+
+        for ox in 0:8:width - 8, oy in 0:8:height - 8
+            drawX, drawY = (ox, oy) .+ offsets[direction] .+ groupedTriggerSpikesOffset
+            Ahorn.drawSprite(ctx, "danger/spikes/$(variant)_$(direction)00", drawX, drawY)
+        end
+    end
+end
+
+end

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -90,3 +90,9 @@ placements.entities.SpringCollab2020/FlagSwitchGate.tooltips.inactiveColor=The g
 placements.entities.SpringCollab2020/FlagSwitchGate.tooltips.activeColor=The gate icon colour when triggered, but the group is not complete yet.
 placements.entities.SpringCollab2020/FlagSwitchGate.tooltips.finishColor=The gate icon colour when the group is complete.
 placements.entities.SpringCollab2020/FlagSwitchGate.tooltips.sprite=The texture for the gate block.
+
+# Grouped Trigger Spikes
+placements.entities.SpringCollab2020/GroupedTriggerSpikesUp.tooltips.type=Changes the visual appearance of the spikes.
+placements.entities.SpringCollab2020/GroupedTriggerSpikesDown.tooltips.type=Changes the visual appearance of the spikes.
+placements.entities.SpringCollab2020/GroupedTriggerSpikesLeft.tooltips.type=Changes the visual appearance of the spikes.
+placements.entities.SpringCollab2020/GroupedTriggerSpikesRight.tooltips.type=Changes the visual appearance of the spikes.

--- a/Entities/GroupedTriggerSpikes.cs
+++ b/Entities/GroupedTriggerSpikes.cs
@@ -24,11 +24,9 @@ namespace Celeste.Mod.Entities {
         public static Entity LoadRight(Level level, LevelData levelData, Vector2 offset, EntityData entityData)
             => new GroupedTriggerSpikes(entityData, offset, Directions.Right);
 
-        private const float RetractTime = 6f;
         private const float DelayTime = 0.4f;
 
         public bool Triggered = false;
-        public float RetractTimer;
         public float DelayTimer;
         public float Lerp;
 
@@ -171,7 +169,6 @@ namespace Celeste.Mod.Entities {
                 Audio.Play("event:/game/03_resort/fluff_tendril_touch", Position + spikePositions[minIndex]);
                 Triggered = true;
                 DelayTimer = DelayTime;
-                RetractTimer = RetractTime;
             } else if (Lerp >= 1f) {
                 player.Die(outwards);
             }

--- a/Entities/GroupedTriggerSpikes.cs
+++ b/Entities/GroupedTriggerSpikes.cs
@@ -1,0 +1,312 @@
+﻿using FMOD.Studio;
+using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.Entities {
+    /// <summary>
+    /// TriggerSpikes that all come out when leaving the group.
+    /// </summary>
+    [CustomEntity(
+        "SpringCollab2020/GroupedTriggerSpikesUp = LoadUp",
+        "SpringCollab2020/GroupedTriggerSpikesDown = LoadDown",
+        "SpringCollab2020/GroupedTriggerSpikesLeft = LoadLeft",
+        "SpringCollab2020/GroupedTriggerSpikesRight = LoadRight"
+    )]
+    public class GroupedTriggerSpikes : Entity {
+
+        public static Entity LoadUp(Level level, LevelData levelData, Vector2 offset, EntityData entityData)
+            => new GroupedTriggerSpikes(entityData, offset, Directions.Up);
+        public static Entity LoadDown(Level level, LevelData levelData, Vector2 offset, EntityData entityData)
+            => new GroupedTriggerSpikes(entityData, offset, Directions.Down);
+        public static Entity LoadLeft(Level level, LevelData levelData, Vector2 offset, EntityData entityData)
+            => new GroupedTriggerSpikes(entityData, offset, Directions.Left);
+        public static Entity LoadRight(Level level, LevelData levelData, Vector2 offset, EntityData entityData)
+            => new GroupedTriggerSpikes(entityData, offset, Directions.Right);
+
+        private const float RetractTime = 6f;
+        private const float DelayTime = 0.4f;
+
+        public bool Triggered = false;
+        public float RetractTimer;
+        public float DelayTimer;
+        public float Lerp;
+
+        private int size;
+        private Directions direction;
+        private string overrideType;
+
+        private Vector2 outwards;
+
+        private Vector2 shakeOffset;
+
+        private string spikeType;
+
+        private Vector2[] spikePositions;
+        private List<MTexture> spikeTextures;
+
+        public GroupedTriggerSpikes(EntityData data, Vector2 offset, Directions dir)
+            : this(data.Position + offset, GetSize(data, dir), dir, data.Attr("type", "default")) {
+        }
+
+        public GroupedTriggerSpikes(Vector2 position, int size, Directions direction, string overrideType)
+            : base(position) {
+
+            this.size = size;
+            this.direction = direction;
+            this.overrideType = overrideType;
+
+            switch (direction) {
+                case Directions.Up:
+                    outwards = new Vector2(0f, -1f);
+                    Collider = new Hitbox(size, 3f, 0f, -3f);
+                    Add(new SafeGroundBlocker());
+                    Add(new LedgeBlocker(UpSafeBlockCheck));
+                    break;
+
+                case Directions.Down:
+                    outwards = new Vector2(0f, 1f);
+                    Collider = new Hitbox(size, 3f, 0f, 0f);
+                    break;
+
+                case Directions.Left:
+                    outwards = new Vector2(-1f, 0f);
+                    Collider = new Hitbox(3f, size, -3f, 0f);
+
+                    Add(new SafeGroundBlocker());
+                    Add(new LedgeBlocker(SideSafeBlockCheck));
+                    break;
+
+                case Directions.Right:
+                    outwards = new Vector2(1f, 0f);
+                    Collider = new Hitbox(3f, size, 0f, 0f);
+
+                    Add(new SafeGroundBlocker());
+                    Add(new LedgeBlocker(SideSafeBlockCheck));
+                    break;
+            }
+
+            Add(new PlayerCollider(OnCollide));
+
+            Add(new StaticMover {
+                OnShake = OnShake,
+                SolidChecker = IsRiding,
+                JumpThruChecker = IsRiding
+            });
+
+            Depth = -50;
+        }
+
+        public override void Added(Scene scene) {
+            base.Added(scene);
+
+            AreaData areaData = AreaData.Get(scene);
+            spikeType = areaData.Spike;
+            if (!string.IsNullOrEmpty(overrideType) && overrideType != "default") {
+                spikeType = overrideType;
+            }
+
+            string dir = direction.ToString().ToLower();
+
+            if (spikeType == "tentacles") {
+                throw new NotSupportedException("Trigger tentacles currently not supported");
+            }
+
+            spikePositions = new Vector2[size / 8];
+            spikeTextures = GFX.Game.GetAtlasSubtextures("danger/spikes/" + spikeType + "_" + dir);
+            for (int i = 0; i < spikePositions.Length; i++) {
+                switch (direction) {
+                    case Directions.Up:
+                        spikePositions[i] = Vector2.UnitX * (i + 0.5f) * 8f + Vector2.UnitY;
+                        break;
+
+                    case Directions.Down:
+                        spikePositions[i] = Vector2.UnitX * (i + 0.5f) * 8f - Vector2.UnitY;
+                        break;
+
+                    case Directions.Left:
+                        spikePositions[i] = Vector2.UnitY * (i + 0.5f) * 8f + Vector2.UnitX;
+                        break;
+
+                    case Directions.Right:
+                        spikePositions[i] = Vector2.UnitY * (i + 0.5f) * 8f - Vector2.UnitX;
+                        break;
+                }
+            }
+        }
+
+        private void OnShake(Vector2 amount) {
+            shakeOffset += amount;
+        }
+
+        private bool UpSafeBlockCheck(Player player) {
+            int dir = 8 * (int) player.Facing;
+            int left = (int) ((player.Left + dir - Left) / 4f);
+            int right = (int) ((player.Right + dir - Left) / 4f);
+
+            if (right < 0 || left >= spikePositions.Length) {
+                return false;
+            }
+
+            return Lerp >= 1f;
+        }
+
+        private bool SideSafeBlockCheck(Player player) {
+            int top = (int) ((player.Top - Top) / 4f);
+            int bottom = (int) ((player.Bottom - Top) / 4f);
+
+            if (bottom < 0 || top >= spikePositions.Length)
+                return false;
+
+            return Lerp >= 1f;
+        }
+
+        private void OnCollide(Player player) {
+            GetPlayerCollideIndex(player, out int minIndex, out int maxIndex);
+            if (maxIndex < 0 || minIndex >= spikePositions.Length) {
+                return;
+            }
+
+            if (!Triggered) {
+                Audio.Play("event:/game/03_resort/fluff_tendril_touch", Position + spikePositions[minIndex]);
+                Triggered = true;
+                DelayTimer = DelayTime;
+                RetractTimer = RetractTime;
+            } else if (Lerp >= 1f) {
+                player.Die(outwards);
+            }
+        }
+
+        private void GetPlayerCollideIndex(Player player, out int minIndex, out int maxIndex) {
+            minIndex = maxIndex = -1;
+
+            switch (direction) {
+                case Directions.Up:
+                    if (player.Speed.Y >= 0f) {
+                        minIndex = (int) ((player.Left - Left) / 8f);
+                        maxIndex = (int) ((player.Right - Left) / 8f);
+                    }
+                    break;
+
+                case Directions.Down:
+                    if (player.Speed.Y <= 0f) {
+                        minIndex = (int) ((player.Left - Left) / 8f);
+                        maxIndex = (int) ((player.Right - Left) / 8f);
+                    }
+                    break;
+
+                case Directions.Left:
+                    if (player.Speed.X >= 0f) {
+                        minIndex = (int) ((player.Top - Top) / 8f);
+                        maxIndex = (int) ((player.Bottom - Top) / 8f);
+                    }
+                    break;
+
+                case Directions.Right:
+                    if (player.Speed.X <= 0f) {
+                        minIndex = (int) ((player.Top - Top) / 8f);
+                        maxIndex = (int) ((player.Bottom - Top) / 8f);
+                    }
+                    break;
+            }
+        }
+
+        private bool PlayerCheck() {
+            Player player = CollideFirst<Player>();
+            if (player == null) {
+                return false;
+            }
+
+            GetPlayerCollideIndex(player, out int minIndex, out int maxIndex);
+            return minIndex != -1 && maxIndex != -1;
+        }
+
+        private static int GetSize(EntityData data, Directions dir) {
+            return
+                dir > Directions.Down ?
+                data.Height :
+                data.Width;
+        }
+
+        public override void Update() {
+            base.Update();
+
+            if (Triggered) {
+                if (DelayTimer > 0f) {
+                    DelayTimer -= Engine.DeltaTime;
+                    if (DelayTimer <= 0f) {
+                        if (PlayerCheck()) {
+                            DelayTimer = 0.05f;
+                        } else {
+                            Audio.Play("event:/game/03_resort/fluff_tendril_emerge", Position + spikePositions[spikePositions.Length / 2]);
+                        }
+                    }
+                } else {
+                    Lerp = Calc.Approach(Lerp, 1f, 8f * Engine.DeltaTime);
+                }
+            } else {
+                Lerp = Calc.Approach(Lerp, 0f, 4f * Engine.DeltaTime);
+                if (Lerp <= 0f) {
+                    Triggered = false;
+                }
+            }
+        }
+
+        public override void Render() {
+            base.Render();
+
+            Vector2 justify = Vector2.One * 0.5f;
+            switch (direction) {
+                case Directions.Up:
+                    justify = new Vector2(0.5f, 1f);
+                    break;
+                case Directions.Down:
+                    justify = new Vector2(0.5f, 0f);
+                    break;
+                case Directions.Left:
+                    justify = new Vector2(1f, 0.5f);
+                    break;
+                case Directions.Right:
+                    justify = new Vector2(0f, 0.5f);
+                    break;
+            }
+
+            for (int i = 0; i < spikePositions.Length; i++) {
+                MTexture tex = spikeTextures[0];
+                Vector2 pos = Position + shakeOffset + spikePositions[i] + outwards * (-4f + Lerp * 4f);
+                tex.DrawJustified(pos, justify);
+            }
+        }
+
+        private bool IsRiding(Solid solid) {
+            switch (direction) {
+                case Directions.Up:
+                    return CollideCheckOutside(solid, Position + Vector2.UnitY);
+                case Directions.Down:
+                    return CollideCheckOutside(solid, Position - Vector2.UnitY);
+                case Directions.Left:
+                    return CollideCheckOutside(solid, Position + Vector2.UnitX);
+                case Directions.Right:
+                    return CollideCheckOutside(solid, Position - Vector2.UnitX);
+                default:
+                    return false;
+            }
+        }
+
+        private bool IsRiding(JumpThru jumpThru) {
+            return direction == Directions.Up && CollideCheck(jumpThru, Position + Vector2.UnitY);
+        }
+
+        public enum Directions {
+            Up,
+            Down,
+            Left,
+            Right
+        }
+    }
+}

--- a/Entities/GroupedTriggerSpikes.cs
+++ b/Entities/GroupedTriggerSpikes.cs
@@ -1,12 +1,7 @@
-﻿using FMOD.Studio;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Monocle;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Celeste.Mod.Entities {
     /// <summary>
@@ -216,16 +211,6 @@ namespace Celeste.Mod.Entities {
             }
         }
 
-        private bool PlayerCheck() {
-            Player player = CollideFirst<Player>();
-            if (player == null) {
-                return false;
-            }
-
-            GetPlayerCollideIndex(player, out int minIndex, out int maxIndex);
-            return minIndex != -1 && maxIndex != -1;
-        }
-
         private static int GetSize(EntityData data, Directions dir) {
             return
                 dir > Directions.Down ?
@@ -240,7 +225,7 @@ namespace Celeste.Mod.Entities {
                 if (DelayTimer > 0f) {
                     DelayTimer -= Engine.DeltaTime;
                     if (DelayTimer <= 0f) {
-                        if (PlayerCheck()) {
+                        if (CollideCheck<Player>()) {
                             DelayTimer = 0.05f;
                         } else {
                             Audio.Play("event:/game/03_resort/fluff_tendril_emerge", Position + spikePositions[spikePositions.Length / 2]);


### PR DESCRIPTION
Closes #90.

Based on Trigger Spikes from Everest, but edited to make all spikes rise at the same time when the player leaves the group.

Again, lots of copy-pastes, both on the Ahorn and on the C# side.