### PR TITLE
Instant Falling Blocks

### DIFF
--- a/Ahorn/entities/instantFallingBlock.jl
+++ b/Ahorn/entities/instantFallingBlock.jl
@@ -1,0 +1,28 @@
+module SpringCollab2020InstantFallingBlock
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/InstantFallingBlock" InstantFallingBlock(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
+    tiletype::String="3", climbFall::Bool=true, behind::Bool=false)
+
+const placements = Ahorn.PlacementDict(
+    "Instant Falling Block (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        InstantFallingBlock,
+        "rectangle",
+        Dict{String, Any}(),
+        Ahorn.tileEntityFinalizer
+    ),
+)
+
+Ahorn.editingOptions(entity::InstantFallingBlock) = Dict{String, Any}(
+    "tiletype" => Ahorn.tiletypeEditingOptions()
+)
+
+Ahorn.minimumSize(entity::InstantFallingBlock) = 8, 8
+Ahorn.resizable(entity::InstantFallingBlock) = true, true
+
+Ahorn.selection(entity::InstantFallingBlock) = Ahorn.getEntityRectangle(entity)
+
+Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::InstantFallingBlock, room::Maple.Room) = Ahorn.drawTileEntity(ctx, room, entity)
+
+end

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -90,3 +90,8 @@ placements.entities.SpringCollab2020/FlagSwitchGate.tooltips.inactiveColor=The g
 placements.entities.SpringCollab2020/FlagSwitchGate.tooltips.activeColor=The gate icon colour when triggered, but the group is not complete yet.
 placements.entities.SpringCollab2020/FlagSwitchGate.tooltips.finishColor=The gate icon colour when the group is complete.
 placements.entities.SpringCollab2020/FlagSwitchGate.tooltips.sprite=The texture for the gate block.
+
+# Instant Falling Block
+placements.entities.SpringCollab2020/InstantFallingBlock.tooltips.climbFall=After a delay, the block will physically fall down until it comes into contact with another block.
+placements.entities.SpringCollab2020/InstantFallingBlock.tooltips.tiletype=Changes the visual appearance of the falling block.
+placements.entities.SpringCollab2020/InstantFallingBlock.tooltips.behind=Whether the block should visually be further behind in the scene or not.

--- a/Entities/InstantFallingBlock.cs
+++ b/Entities/InstantFallingBlock.cs
@@ -1,0 +1,12 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    [CustomEntity("SpringCollab2020/InstantFallingBlock")]
+    class InstantFallingBlock : FallingBlock {
+        public InstantFallingBlock(EntityData data, Vector2 offset) : base(data, offset) {
+            // this block starts triggered right away. that's about it.
+            Triggered = true;
+        }
+    }
+}


### PR DESCRIPTION
Closes #94.

Falling Blocks, except they don't wait for the player to fall, they are triggered right away.