### PR TITLE
Make seeker explosions trigger flag touch switches

### DIFF
--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -21,6 +21,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             BubbleReturnBerry.Load();
             SidewaysJumpThru.Load();
             CrystalBombDetonatorRenderer.Load();
+            FlagTouchSwitch.Load();
         }
 
         public override void LoadContent(bool firstLoad) {
@@ -40,6 +41,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             BubbleReturnBerry.Unload();
             SidewaysJumpThru.Unload();
             CrystalBombDetonatorRenderer.Unload();
+            FlagTouchSwitch.Unload();
         }
 
         public override void PrepareMapDataProcessors(MapDataFixup context) {


### PR DESCRIPTION
Just a small oversight, since the seekers check for collision with touch switches themselves.