### PR TITLE
Fix patch order for upside-down jumpthru player constructor patch

### DIFF
--- a/Entities/UpsideDownJumpThru.cs
+++ b/Entities/UpsideDownJumpThru.cs
@@ -28,8 +28,10 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
                 On.Celeste.Platform.MoveVExactCollideSolids += onPlatformMoveVExactCollideSolids;
             }
 
-            // fix player specific behavior allowing them to go through upside-down jumpthrus.
-            On.Celeste.Player.ctor += onPlayerConstructor;
+            using (new DetourContext { After = { "*" } }) {
+                // fix player specific behavior allowing them to go through upside-down jumpthrus.
+                On.Celeste.Player.ctor += onPlayerConstructor;
+            }
 
             // block player if they try to climb past an upside-down jumpthru.
             IL.Celeste.Player.ClimbUpdate += patchPlayerClimbUpdate;


### PR DESCRIPTION
Fixes upside-down jumpthrus if Extended Variants are loaded **after** Spring Collab 2020. Extended Variants have an IL hook on the Player constructor.