### PR TITLE
Bird tutorial with custom text and controls

### DIFF
--- a/Ahorn/entities/customBirdTutorial.jl
+++ b/Ahorn/entities/customBirdTutorial.jl
@@ -1,0 +1,32 @@
+module SpringCollab2020CustomBirdTutorial
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/CustomBirdTutorial" CustomBirdTutorial(x::Integer, y::Integer,
+    birdId::String="birdId", onlyOnce::Bool=false, caw::Bool=true, faceLeft::Bool=true, info::String="tutorial_dreamjump", controls::String="DownRight,+,Dash,tinyarrow,Jump")
+
+const placements = Ahorn.PlacementDict(
+    "Custom Bird Tutorial (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        CustomBirdTutorial
+    )
+)
+
+sprite = "characters/bird/crow00"
+
+function Ahorn.selection(entity::CustomBirdTutorial)
+    nodes = get(entity.data, "nodes", ())
+    x, y = Ahorn.position(entity)
+    key = lowercase(get(entity.data, "mode", "Sleeping"))
+    scaleX = get(entity.data, "faceLeft", true) ? -1 : 1
+
+    return Ahorn.Rectangle[Ahorn.getSpriteRectangle(sprite, x, y, sx=scaleX, jx=0.5, jy=1.0)]
+end
+
+function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::CustomBirdTutorial, room::Maple.Room)
+    key = lowercase(get(entity.data, "mode", "Sleeping"))
+    scaleX = get(entity.data, "faceLeft", true) ? -1 : 1
+    
+    Ahorn.drawSprite(ctx, sprite, 0, 0, sx=scaleX, jx=0.5, jy=1.0)
+end
+
+end

--- a/Ahorn/entities/customBirdTutorial.jl
+++ b/Ahorn/entities/customBirdTutorial.jl
@@ -14,16 +14,13 @@ const placements = Ahorn.PlacementDict(
 sprite = "characters/bird/crow00"
 
 function Ahorn.selection(entity::CustomBirdTutorial)
-    nodes = get(entity.data, "nodes", ())
     x, y = Ahorn.position(entity)
-    key = lowercase(get(entity.data, "mode", "Sleeping"))
     scaleX = get(entity.data, "faceLeft", true) ? -1 : 1
 
     return Ahorn.Rectangle[Ahorn.getSpriteRectangle(sprite, x, y, sx=scaleX, jx=0.5, jy=1.0)]
 end
 
 function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::CustomBirdTutorial, room::Maple.Room)
-    key = lowercase(get(entity.data, "mode", "Sleeping"))
     scaleX = get(entity.data, "faceLeft", true) ? -1 : 1
     
     Ahorn.drawSprite(ctx, sprite, 0, 0, sx=scaleX, jx=0.5, jy=1.0)

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -115,3 +115,15 @@ placements.entities.SpringCollab2020/NoDashRefillSpring.tooltips.playerCanUse=De
 
 # Underwater Switch Controller
 placements.entities.SpringCollab2020/UnderwaterSwitchController.tooltips.flag=The session flag the controller is listening to. Activating this flag will flood the room with water, deactivating it will remove that water.
+
+# Custom Bird Tutorial
+placements.entities.SpringCollab2020/CustomBirdTutorial.tooltips.birdId=An identifier for the bird. Used to tie the bird to its trigger if there are multiple birds in a same room.
+placements.entities.SpringCollab2020/CustomBirdTutorial.tooltips.info=The bubble "title". Can either be a dialog ID, or a path to a texture in the Gui atlas.
+placements.entities.SpringCollab2020/CustomBirdTutorial.tooltips.caw=Whether the bird should caw upon displaying the bubble.
+placements.entities.SpringCollab2020/CustomBirdTutorial.tooltips.faceLeft=Whether the bird should face left or right.
+placements.entities.SpringCollab2020/CustomBirdTutorial.tooltips.onlyOnce=If enabled, the bird won't respawn once it flew away, even if the player dies in the room.
+placements.entities.SpringCollab2020/CustomBirdTutorial.tooltips.controls=The controls to display in the bubble, separated by commas. Each part can be:\n- a path to a texture in the Gui atlas (for example "tinyarrow")\n- a direction: Down, DownRight, Right, UpRight, Up, UpLeft, Left, DownLeft\n- a button: Jump, Dash, Grab, Talk, ESC, Pause, MenuLeft, MenuRight, MenuUp, MenuDown, MenuConfirm, MenuCancel, MenuJournal, QuickRestart\n- a dialog ID, if you prefix it with "dialog:" (for example, "dialog:TUTORIAL_DREAMJUMP")\n- plain text
+
+# Custom Bird Tutorial Trigger
+placements.triggers.SpringCollab2020/CustomBirdTutorialTrigger.tooltips.birdId=The ID of the bird this trigger is controlling.
+placements.triggers.SpringCollab2020/CustomBirdTutorialTrigger.tooltips.showTutorial=If checked, the trigger will make the bird show the tutorial bubble. If unchecked, the trigger will make the bird fly away.

--- a/Ahorn/triggers/customBirdTutorial.jl
+++ b/Ahorn/triggers/customBirdTutorial.jl
@@ -9,7 +9,7 @@ const placements = Ahorn.PlacementDict(
     "Custom Bird Tutorial Trigger (Spring Collab 2020)" => Ahorn.EntityPlacement(
         CustomBirdTutorialTrigger,
         "rectangle"
-    ),
+    )
 )
 
 end

--- a/Ahorn/triggers/customBirdTutorial.jl
+++ b/Ahorn/triggers/customBirdTutorial.jl
@@ -1,0 +1,15 @@
+module SpringCollab2020CustomBirdTutorialTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/CustomBirdTutorialTrigger" CustomBirdTutorialTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
+    birdId::String="birdId", showTutorial::Bool=true)
+
+const placements = Ahorn.PlacementDict(
+    "Custom Bird Tutorial Trigger (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        CustomBirdTutorialTrigger,
+        "rectangle"
+    ),
+)
+
+end

--- a/Ahorn/triggers/customBirdTutorial.jl
+++ b/Ahorn/triggers/customBirdTutorial.jl
@@ -6,7 +6,7 @@ using ..Ahorn, Maple
     birdId::String="birdId", showTutorial::Bool=true)
 
 const placements = Ahorn.PlacementDict(
-    "Custom Bird Tutorial Trigger (Spring Collab 2020)" => Ahorn.EntityPlacement(
+    "Custom Bird Tutorial (Spring Collab 2020)" => Ahorn.EntityPlacement(
         CustomBirdTutorialTrigger,
         "rectangle"
     )

--- a/Entities/CustomBirdTutorial.cs
+++ b/Entities/CustomBirdTutorial.cs
@@ -1,0 +1,98 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    [CustomEntity("SpringCollab2020/CustomBirdTutorial")]
+    [Tracked]
+    class CustomBirdTutorial : BirdNPC {
+        public string BirdId;
+        private bool onlyOnce;
+        private bool caw;
+
+        private bool triggered = false;
+        private bool flewAway = false;
+
+        private BirdTutorialGui gui;
+
+        private static Dictionary<string, Vector2> directions = new Dictionary<string, Vector2>() {
+            { "Left", new Vector2(-1, 0) },
+            { "Right", new Vector2(1, 0) },
+            { "Up", new Vector2(0, -1) },
+            { "Down", new Vector2(0, 1) },
+            { "UpLeft", new Vector2(-1, -1) },
+            { "UpRight", new Vector2(1, -1) },
+            { "DownLeft", new Vector2(-1, 1) },
+            { "DownRight", new Vector2(1, 1) }
+        };
+
+        public CustomBirdTutorial(EntityData data, Vector2 offset) : base(data, offset) {
+            BirdId = data.Attr("birdId");
+            onlyOnce = data.Bool("onlyOnce");
+            caw = data.Bool("caw");
+            Facing = data.Bool("faceLeft") ? Facings.Left : Facings.Right;
+
+            object info;
+            object[] controls;
+
+            // parse the info ("title")
+            string infoString = data.Attr("info");
+            if (GFX.Gui.Has(infoString)) {
+                info = GFX.Gui[infoString];
+            } else {
+                info = Dialog.Clean(infoString);
+            }
+
+            // go ahead and parse the controls. Controls can be textures, VirtualButtons, directions or strings.
+            string[] controlsStrings = data.Attr("controls").Split(',');
+            controls = new object[controlsStrings.Length];
+            for (int i = 0; i < controls.Length; i++) {
+                string controlString = controlsStrings[i];
+
+                if (GFX.Gui.Has(controlString)) {
+                    // this is a texture.
+                    controls[i] = GFX.Gui[controlString];
+                } else if (directions.ContainsKey(controlString)) {
+                    // this is a direction.
+                    controls[i] = directions[controlString];
+                } else {
+                    FieldInfo matchingInput = typeof(Input).GetField(controlString, BindingFlags.Static | BindingFlags.Public);
+                    if (matchingInput?.GetValue(null)?.GetType() == typeof(VirtualButton)) {
+                        // this is a button.
+                        controls[i] = matchingInput.GetValue(null);
+                    } else if (controlString.StartsWith("dialog:")) {
+                        // treat that as a dialog key.
+                        controls[i] = Dialog.Clean(controlString.Substring("dialog:".Length));
+                    } else {
+                        // treat that as a plain string.
+                        controls[i] = controlString;
+                    }
+                }
+            }
+
+            gui = new BirdTutorialGui(this, new Vector2(0f, -16f), info, controls);
+        }
+
+        public void TriggerShowTutorial() {
+            if (!triggered) {
+                triggered = true;
+                Add(new Coroutine(ShowTutorial(gui, caw)));
+            }
+        }
+
+        public void TriggerHideTutorial() {
+            if (triggered && !flewAway) {
+                flewAway = true;
+
+                Add(new Coroutine(HideTutorial()));
+                Add(new Coroutine(StartleAndFlyAway()));
+
+                if (onlyOnce) {
+                    SceneAs<Level>().Session.DoNotLoad.Add(EntityID);
+                }
+            }
+        }
+    }
+}

--- a/Triggers/CustomBirdTutorialTrigger.cs
+++ b/Triggers/CustomBirdTutorialTrigger.cs
@@ -1,0 +1,31 @@
+﻿using Celeste.Mod.Entities;
+using Celeste.Mod.SpringCollab2020.Entities;
+using Microsoft.Xna.Framework;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+    [CustomEntity("SpringCollab2020/CustomBirdTutorialTrigger")]
+    class CustomBirdTutorialTrigger : Trigger {
+        private string birdId;
+        private bool showTutorial;
+
+        public CustomBirdTutorialTrigger(EntityData data, Vector2 offset) : base(data, offset) {
+            birdId = data.Attr("birdId");
+            showTutorial = data.Bool("showTutorial");
+        }
+
+        public override void OnEnter(Player player) {
+            base.OnEnter(player);
+
+            CustomBirdTutorial matchingBird = (CustomBirdTutorial)
+                Scene.Tracker.GetEntities<CustomBirdTutorial>().Find(entity => entity is CustomBirdTutorial bird && bird.BirdId == birdId);
+
+            if (matchingBird != null) {
+                if (showTutorial) {
+                    matchingBird.TriggerShowTutorial();
+                } else {
+                    matchingBird.TriggerHideTutorial();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #60.

A tutorial bird that shows an arbitrary button combination. The tutorial bubble shows up when the player enters a trigger, and the bird flies away when the player enters another trigger. The "bird ID" is only useful if multiple birds are in the same room, to bind birds to triggers.

Vanilla allows for various things to be put in tutorial bird bubbles: textures, buttons, directions and strings. The "controls" parameter is quite complex, but powerful, as a result. The default value matches the vanilla hyperjump tutorial.