### PR TITLE
Add flag activation options to Bubble Push Fields

### DIFF
--- a/Ahorn/entities/bubblePushField.jl
+++ b/Ahorn/entities/bubblePushField.jl
@@ -2,7 +2,8 @@
 
 using ..Ahorn, Maple
 
-@mapdef Entity "SpringCollab2020/bubblePushField" BubblePushField(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight, strength::Number=1, upwardStrength::Number=1, direction::String="Right", water::Bool=true)
+@mapdef Entity "SpringCollab2020/bubblePushField" BubblePushField(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
+	strength::Number=1, upwardStrength::Number=1, direction::String="Right", water::Bool=true, flag::String="bubble_push_field", activationMode::String="Always")
 
 const placements = Ahorn.PlacementDict(
 	"Bubble Column (Spring Collab 2020)" => Ahorn.EntityPlacement(
@@ -12,7 +13,8 @@ const placements = Ahorn.PlacementDict(
 )
 
 Ahorn.editingOptions(entity::BubblePushField) = Dict{String,Any}(
-	"direction" => ["Up", "Down", "Left", "Right"]
+	"direction" => ["Up", "Down", "Left", "Right"],
+	"activationMode" => ["Always", "OnlyWhenFlagActive", "OnlyWhenFlagInactive"]
 )
 
 Ahorn.minimumSize(entity::BubblePushField) = 8, 8

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -47,6 +47,8 @@ placements.entities.SpringCollab2020/bubblePushField.tooltips.strength=The stren
 placements.entities.SpringCollab2020/bubblePushField.tooltips.upwardStrength=How much the bubbles push the player up to compensate for gravity.
 placements.entities.SpringCollab2020/bubblePushField.tooltips.direction=The direction the bubbles push the player.
 placements.entities.SpringCollab2020/bubblePushField.tooltips.water=If the bubble field will create a Water entity to make its presence visible.
+placements.entities.SpringCollab2020/bubblePushField.tooltips.activationMode=Determines on which condition the bubble column activates.
+placements.entities.SpringCollab2020/bubblePushField.tooltips.flag=The session flag this bubble push field reacts to (when Activation Mode is "only if flag (in)active").
 
 # Upside Down Jump Thru
 placements.entities.SpringCollab2020/UpsideDownJumpThru.tooltips.texture=Changes the appearance of the platform.

--- a/Entities/BubblePushField.cs
+++ b/Entities/BubblePushField.cs
@@ -30,8 +30,8 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
 
         public PushDirection Direction;
 
-        public ActivationMode activationMode;
-        public string flag;
+        private ActivationMode activationMode;
+        private string flag;
 
         public BubblePushField(EntityData data, Vector2 offset) : this(
             data.Position + offset,

--- a/Entities/BubblePushField.cs
+++ b/Entities/BubblePushField.cs
@@ -7,6 +7,10 @@ using Monocle;
 namespace Celeste.Mod.SpringCollab2020.Entities {
     [CustomEntity("SpringCollab2020/bubblePushField")]
     class BubblePushField : Entity {
+        public enum ActivationMode {
+            Always, OnlyWhenFlagActive, OnlyWhenFlagInactive
+        }
+
         public float Strength;
 
         public float UpwardStrength;
@@ -26,6 +30,9 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
 
         public PushDirection Direction;
 
+        public ActivationMode activationMode;
+        public string flag;
+
         public BubblePushField(EntityData data, Vector2 offset) : this(
             data.Position + offset,
             data.Width,
@@ -33,14 +40,18 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             data.Float("strength", 1f),
             data.Float("upwardStrength", 1f),
             data.Attr("direction", "right"),
-            data.Bool("water", true)
+            data.Bool("water", true),
+            data.Enum("activationMode", ActivationMode.Always),
+            data.Attr("flag", "bubble_push_field")
             ) { }
 
-        public BubblePushField(Vector2 position, int width, int height, float strength, float upwardStrength, string direction, bool water) {
+        public BubblePushField(Vector2 position, int width, int height, float strength, float upwardStrength, string direction, bool water, ActivationMode activationMode, string flag) {
             Position = position;
             Strength = strength;
             UpwardStrength = upwardStrength;
             _water = water;
+            this.activationMode = activationMode;
+            this.flag = flag;
 
             Rand = new Random();
 
@@ -69,6 +80,14 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
 
         public override void Update() {
             base.Update();
+
+            Session session = SceneAs<Level>().Session;
+            if ((activationMode == ActivationMode.OnlyWhenFlagActive && !session.GetFlag(flag)) 
+                || (activationMode == ActivationMode.OnlyWhenFlagInactive && session.GetFlag(flag))) {
+
+                // the bubble push field is currently turned off by a session flag.
+                return;
+            }
 
             FramesSinceSpawn++;
             if (FramesSinceSpawn == SpawnFrame) {


### PR DESCRIPTION
Closes part of #102, core switch part should be coming in Pandora's Box.

Adds two new attributes for Bubble Push Fields: "activationMode" and "flag". This allows to set up bubble push fields to be only active when a certain session flag is set, or not set. The default value ("Always") matches their current behavior, so this shouldn't break existing maps.