### PR TITLE
Fix remove light source trigger

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -32,9 +32,6 @@ placements.triggers.SpringCollab2020/SmoothCameraOffsetTrigger.tooltips.offsetYT
 placements.triggers.SpringCollab2020/SmoothCameraOffsetTrigger.tooltips.positionMode=The fade direction.
 placements.triggers.SpringCollab2020/SmoothCameraOffsetTrigger.tooltips.onlyOnce=If checked, the trigger will be disabled when the player first leaves it.
 
-# Remove Light Sources Trigger
-placements.triggers.SpringCollab2020/RemoveLightSourcesTrigger.tooltips.persistent=If checked, all light sources will stay disabled even after leaving the trigger.
-
 # Dash Spring
 placements.entities.SpringCollab2020/dashSpring.tooltips.playerCanUse=Determines whether the player is able to interact with the spring.
 

--- a/Ahorn/triggers/removeLightSourcesTrigger.jl
+++ b/Ahorn/triggers/removeLightSourcesTrigger.jl
@@ -2,7 +2,7 @@
 
 using ..Ahorn, Maple
 
-@mapdef Trigger "SpringCollab2020/RemoveLightSourcesTrigger" RemoveLightSourcesTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight, persistent::Bool=true)
+@mapdef Trigger "SpringCollab2020/RemoveLightSourcesTrigger" RemoveLightSourcesTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight)
 
 const placements = Ahorn.PlacementDict(
     "Remove Light Sources (Spring Collab 2020)" => Ahorn.EntityPlacement(

--- a/Triggers/RemoveLightSourcesTrigger.cs
+++ b/Triggers/RemoveLightSourcesTrigger.cs
@@ -1,6 +1,7 @@
 ﻿using Celeste.Mod.Entities;
 using Monocle;
 using Microsoft.Xna.Framework;
+using System.Reflection;
 
 namespace Celeste.Mod.SpringCollab2020.Triggers {
     [CustomEntity("SpringCollab2020/RemoveLightSourcesTrigger")]
@@ -29,17 +30,21 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
             EnableLightRender();
         }
 
-        private static void LightRendererHook(On.Celeste.LightingRenderer.orig_Render orig, LightingRenderer self, Scene scene) { }
-
         private static void BloomRendererHook(On.Celeste.BloomRenderer.orig_Apply orig, BloomRenderer self, VirtualRenderTarget target, Scene scene) { }
 
+        private static void LightHook(On.Celeste.VertexLight.orig_Update orig, VertexLight self) {
+            if (self.SceneAs<Level>().Session.GetFlag("lightsDisabled"))
+                self.Alpha = 0f;
+            orig(self);
+        }
+
         private static void EnableLightRender() {
-            On.Celeste.LightingRenderer.Render -= LightRendererHook;
+            On.Celeste.VertexLight.Update -= LightHook;
             On.Celeste.BloomRenderer.Apply -= BloomRendererHook;
         }
 
         private static void DisableLightRender() {
-            On.Celeste.LightingRenderer.Render += LightRendererHook;
+            On.Celeste.VertexLight.Update += LightHook;
             On.Celeste.BloomRenderer.Apply += BloomRendererHook;
         }
 

--- a/Triggers/RemoveLightSourcesTrigger.cs
+++ b/Triggers/RemoveLightSourcesTrigger.cs
@@ -1,14 +1,12 @@
 ﻿using Celeste.Mod.Entities;
 using Monocle;
 using Microsoft.Xna.Framework;
-using System.Collections.Generic;
 
 namespace Celeste.Mod.SpringCollab2020.Triggers {
     [CustomEntity("SpringCollab2020/RemoveLightSourcesTrigger")]
     [Tracked]
     class RemoveLightSourcesTrigger : Trigger {
         public RemoveLightSourcesTrigger(EntityData data, Vector2 offset) : base(data, offset) {
-            Persistent = data.Bool("persistent", true);
             level = SceneAs<Level>();
         }
 
@@ -23,40 +21,26 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
         }
 
         private static void LevelLoadHandler(Level loadedLevel, Player.IntroTypes playerIntro, bool isFromLoader) {
-            if (loadedLevel.Session.GetFlag("lightsDisabled")) {
-                DisableAllLights(loadedLevel);
-                On.Celeste.Level.TransitionTo += TransitionLightSources;
-            }
+            if (loadedLevel.Session.GetFlag("lightsDisabled"))
+                DisableLightRender();
         }
 
         private static void OnExitHandler(Level exitLevel, LevelExit exit, LevelExit.Mode mode, Session session, HiresSnow snow) {
-            On.Celeste.Level.TransitionTo -= TransitionLightSources;
+            EnableLightRender();
         }
 
-        private static void TransitionLightSources(On.Celeste.Level.orig_TransitionTo orig, Level transitionLevel, LevelData next, Vector2 direction) {
-            lightSources = new List<Component>();
-            bloomSources = new List<Component>();
+        private static void LightRendererHook(On.Celeste.LightingRenderer.orig_Render orig, LightingRenderer self, Scene scene) { }
 
-            DisableAllLights(transitionLevel);
-            orig(transitionLevel, next, direction);
+        private static void BloomRendererHook(On.Celeste.BloomRenderer.orig_Apply orig, BloomRenderer self, VirtualRenderTarget target, Scene scene) { }
+
+        private static void EnableLightRender() {
+            On.Celeste.LightingRenderer.Render -= LightRendererHook;
+            On.Celeste.BloomRenderer.Apply -= BloomRendererHook;
         }
 
-        private static void DisableAllLights(Level disableLevel) {
-            EntityList entities = disableLevel.Entities;
-
-            foreach (Entity entity in entities) {
-                foreach (Component component in entity.Components.ToArray()) {
-                    if (component is VertexLight) {
-                        lightSources.Add(component);
-                        component.Visible = false;
-                    }
-
-                    if (component is BloomPoint) {
-                        bloomSources.Add(component);
-                        component.Visible = false;
-                    }
-                }
-            }
+        private static void DisableLightRender() {
+            On.Celeste.LightingRenderer.Render += LightRendererHook;
+            On.Celeste.BloomRenderer.Apply += BloomRendererHook;
         }
 
         public override void OnEnter(Player player) {
@@ -64,34 +48,12 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
 
             level = SceneAs<Level>();
 
-            if (Persistent && level.Session.GetFlag("lightsDisabled") == false)
-                On.Celeste.Level.TransitionTo += TransitionLightSources;
-
-            if (Persistent)
+            if (level.Session.GetFlag("lightsDisabled") == false) {
                 level.Session.SetFlag("lightsDisabled", true);
-
-            DisableAllLights(level);
+                DisableLightRender();
+            }
         }
-
-        public override void OnLeave(Player player) {
-            base.OnLeave(player);
-
-            if (Persistent || level.Session.GetFlag("lightsDisabled") == true)
-                return;
-
-            foreach (Component component in lightSources)
-                component.Visible = true;
-
-            foreach (Component component in bloomSources)
-                component.Visible = true;
-        }
-
-        private static List<Component> lightSources = new List<Component>();
-
-        private static List<Component> bloomSources = new List<Component>();
 
         private Level level;
-
-        private bool Persistent = true;
     }
 }


### PR DESCRIPTION
Cookie (who I made this trigger for) discovered that some objects would later re-enable or create new light sources, which the trigger would not handle.

The trigger now disables the bloom renderer, and sets the alpha value of all VertexLights to 0f when lights are disabled. This might(?) cause a bit of a performance hit, but it's the most orthodox solution I could think of.