### PR TITLE
Cassette-friendly strawberry seeds

### DIFF
--- a/Ahorn/entities/cassetteFriendlyStrawberry.jl
+++ b/Ahorn/entities/cassetteFriendlyStrawberry.jl
@@ -33,7 +33,7 @@ function Ahorn.selection(entity::CassetteFriendlyStrawberry)
 
     nodes = get(entity.data, "nodes", ())
     moon = get(entity.data, "moon", false)
-    winged = get(entity.data, "winged", false) || entity.name == "memorialTextController"
+    winged = get(entity.data, "winged", false)
     hasPips = length(nodes) > 0
 
     sprite = sprites[(winged, hasPips, moon)]
@@ -64,7 +64,7 @@ function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::CassetteFriendly
 
     nodes = get(entity.data, "nodes", ())
     moon = get(entity.data, "moon", false)
-    winged = get(entity.data, "winged", false) || entity.name == "memorialTextController"
+    winged = get(entity.data, "winged", false)
     hasPips = length(nodes) > 0
 
     sprite = sprites[(winged, hasPips, moon)]

--- a/Ahorn/entities/cassetteFriendlyStrawberry.jl
+++ b/Ahorn/entities/cassetteFriendlyStrawberry.jl
@@ -1,0 +1,83 @@
+﻿module SpringCollab2020CassetteFriendlyStrawberry
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/CassetteFriendlyStrawberry" CassetteFriendlyStrawberry(x::Integer, y::Integer, winged::Bool=false, moon::Bool=false,
+    checkpointID::Integer=-1, order::Integer=-1, nodes::Array{Tuple{Integer, Integer}, 1}=Tuple{Integer, Integer}[])
+
+const placements = Ahorn.PlacementDict(
+    "Cassette-Friendly Strawberry (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        CassetteFriendlyStrawberry
+    )
+)
+
+# winged, has pips, moon
+sprites = Dict{Tuple{Bool, Bool, Bool}, String}(
+    (false, false, false) => "collectables/strawberry/normal00",
+    (true, false, false) => "collectables/strawberry/wings01",
+    (false, true, false) => "collectables/ghostberry/idle00",
+    (true, true, false) => "collectables/ghostberry/wings01",
+
+    (false, false, true) => "collectables/moonBerry/normal00",
+    (true, false, true) => "collectables/moonBerry/ghost00",
+    (false, true, true) => "collectables/moonBerry/ghost00",
+    (true, true, true) => "collectables/moonBerry/ghost00"
+)
+
+seedSprite = "collectables/strawberry/seed00"
+
+fallback = "collectables/strawberry/normal00"
+
+Ahorn.nodeLimits(entity::CassetteFriendlyStrawberry) = 0, -1
+
+function Ahorn.selection(entity::CassetteFriendlyStrawberry)
+    x, y = Ahorn.position(entity)
+
+    nodes = get(entity.data, "nodes", ())
+    moon = get(entity.data, "moon", false)
+    winged = get(entity.data, "winged", false) || entity.name == "memorialTextController"
+    hasPips = length(nodes) > 0
+
+    sprite = sprites[(winged, hasPips, moon)]
+
+    res = Ahorn.Rectangle[Ahorn.getSpriteRectangle(sprite, x, y)]
+    
+    for node in nodes
+        nx, ny = node
+
+        push!(res, Ahorn.getSpriteRectangle(seedSprite, nx, ny))
+    end
+
+    return res
+end
+
+function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::CassetteFriendlyStrawberry)
+    x, y = Ahorn.position(entity)
+
+    for node in get(entity.data, "nodes", ())
+        nx, ny = node
+
+        Ahorn.drawLines(ctx, Tuple{Number, Number}[(x, y), (nx, ny)], Ahorn.colors.selection_selected_fc)
+    end
+end
+
+function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::CassetteFriendlyStrawberry, room::Maple.Room)
+    x, y = Ahorn.position(entity)
+
+    nodes = get(entity.data, "nodes", ())
+    moon = get(entity.data, "moon", false)
+    winged = get(entity.data, "winged", false) || entity.name == "memorialTextController"
+    hasPips = length(nodes) > 0
+
+    sprite = sprites[(winged, hasPips, moon)]
+
+    for node in nodes
+        nx, ny = node
+
+        Ahorn.drawSprite(ctx, seedSprite, nx, ny)
+    end
+
+    Ahorn.drawSprite(ctx, sprite, x, y)
+end
+
+end

--- a/Ahorn/entities/cassetteFriendlyStrawberry.jl
+++ b/Ahorn/entities/cassetteFriendlyStrawberry.jl
@@ -26,8 +26,6 @@ sprites = Dict{Tuple{Bool, Bool, Bool}, String}(
 
 seedSprite = "collectables/strawberry/seed00"
 
-fallback = "collectables/strawberry/normal00"
-
 Ahorn.nodeLimits(entity::CassetteFriendlyStrawberry) = 0, -1
 
 function Ahorn.selection(entity::CassetteFriendlyStrawberry)

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -136,3 +136,9 @@ placements.entities.SpringCollab2020/MultiNodeMovingPlatform.tooltips.pauseTime=
 placements.entities.SpringCollab2020/MultiNodeMovingPlatform.tooltips.mode=Determines the way the platform will move between its nodes. For example, with 3 nodes A, B, C:\n- Loop: A > B > C > A\n- LoopNoPause: A > A (going through B and C)\n- BackAndForth: A > B > C > B > A\n- BackAndForthNoPause: A > C > A (going through B)\n- TeleportBack: A > B > C, then the platform teleports to A upon reaching C
 placements.entities.SpringCollab2020/MultiNodeMovingPlatform.tooltips.texture=What texture to use for the platform.
 placements.entities.SpringCollab2020/MultiNodeMovingPlatform.tooltips.easing=Whether the platform movement should be eased (speedup/slowdown around each position).
+
+# Cassette-Friendly Strawberry
+placements.entities.SpringCollab2020/CassetteFriendlyStrawberry.tooltips.winged=The strawberry attempts to vertically rise offscreen when the player dashes.
+placements.entities.SpringCollab2020/CassetteFriendlyStrawberry.tooltips.checkpointID=Manually determine what checkpoint section strawberries are visually grouped up in, showing up on the start menu during gameplay and level select. Overrides Everest's automatic berry IDs. (Default= -1)
+placements.entities.SpringCollab2020/CassetteFriendlyStrawberry.tooltips.order=Manually determine what order strawberries are visually placed in on the start menu during gameplay and level select. Overrides Everest's automatic berry IDs. (Default= -1)
+placements.entities.SpringCollab2020/CassetteFriendlyStrawberry.tooltips.moon=Makes the strawberry render as a space berry.\nDoes not work with wings or nodes in the base game.

--- a/Entities/CassetteFriendlyStrawberry.cs
+++ b/Entities/CassetteFriendlyStrawberry.cs
@@ -1,0 +1,24 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    /// <summary>
+    /// Just a strawberry with cassette-friendly strawberry seeds.
+    /// </summary>
+    [CustomEntity("SpringCollab2020/CassetteFriendlyStrawberry")]
+    [RegisterStrawberry(true, false)]
+    class CassetteFriendlyStrawberry : Strawberry {
+        public CassetteFriendlyStrawberry(EntityData data, Vector2 offset, EntityID gid) : base(data, offset, gid) {
+            bool isGhostBerry = SaveData.Instance.CheckStrawberry(ID);
+
+            // we just want to create cassette-friendly strawberry seeds to replace vanilla seeds.
+            if (data.Nodes != null && data.Nodes.Length != 0) {
+                Seeds = new List<StrawberrySeed>();
+                for (int i = 0; i < data.Nodes.Length; i++) {
+                    Seeds.Add(new CassetteFriendlyStrawberrySeed(this, offset + data.Nodes[i], i, isGhostBerry));
+                }
+            }
+        }
+    }
+}

--- a/Entities/CassetteFriendlyStrawberrySeed.cs
+++ b/Entities/CassetteFriendlyStrawberrySeed.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    /// <summary>
+    /// Strawberry seeds that deal nicer with being hidden in cassette blocks.
+    /// They appear when the cassette block disappears, and keep a normal hitbox.
+    /// </summary>
+    class CassetteFriendlyStrawberrySeed : StrawberrySeed {
+
+        bool isInCassetteBlock;
+
+        public CassetteFriendlyStrawberrySeed(Strawberry strawberry, Vector2 position, int index, bool ghost)
+            : base(strawberry, position, index, ghost) { }
+
+        public override void Added(Scene scene) {
+            if (scene.Entities.OfType<CassetteBlock>().Any(block => block.Collider.Bounds.Contains(Collider.Bounds))) {
+                // our seed is entirely inside a cassette block: look for the static mover.
+                foreach (Component component in this) {
+                    if (component is StaticMover mover) {
+                        Remove(mover);
+                        Depth = 11; // just below active cassette blocks
+                        isInCassetteBlock = true;
+                        break;
+                    }
+                }
+            }
+
+            base.Added(scene);
+        }
+
+        public override void Update() {
+            base.Update();
+
+            if (isInCassetteBlock && !Visible) {
+                Depth = 11; // reset depth when losing the seed
+            }
+        }
+    }
+}

--- a/Entities/CassetteFriendlyStrawberrySeed.cs
+++ b/Entities/CassetteFriendlyStrawberrySeed.cs
@@ -1,17 +1,16 @@
 ﻿using Microsoft.Xna.Framework;
 using Monocle;
-using System;
 using System.Linq;
-using System.Reflection;
 
 namespace Celeste.Mod.SpringCollab2020.Entities {
     /// <summary>
     /// Strawberry seeds that deal nicer with being hidden in cassette blocks.
-    /// They appear when the cassette block disappears, and keep a normal hitbox.
+    /// - Their depth is adjusted to appear in front of disabled cassette blocks, but behind enabled ones.
+    /// - They are not "attached", meaning they won't disappear when the cassette block disappears.
     /// </summary>
     class CassetteFriendlyStrawberrySeed : StrawberrySeed {
 
-        bool isInCassetteBlock;
+        private bool isInCassetteBlock;
 
         public CassetteFriendlyStrawberrySeed(Strawberry strawberry, Vector2 position, int index, bool ghost)
             : base(strawberry, position, index, ghost) { }
@@ -21,8 +20,8 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
                 // our seed is entirely inside a cassette block: look for the static mover.
                 foreach (Component component in this) {
                     if (component is StaticMover mover) {
-                        Remove(mover);
-                        Depth = 11; // just below active cassette blocks
+                        Remove(mover); // get rid of behavior like "disappear with cassette block" or "get double-size hitbox"
+                        Depth = 11; // display just below active cassette blocks
                         isInCassetteBlock = true;
                         break;
                     }


### PR DESCRIPTION
Closes #86.

Strawberry seeds but with two tweaks:
- when uncollected, their depth is 11. The maximum depth for active cassette blocks is 10, so this is just behind that.
- they don't attach to platforms. No idea why they attach to platforms in vanilla in the first place, but we don't want the side-effects of it for cassette blocks (seeds disappear with the block, and their hitbox is twice as big... for some reason). This is done by removing the `StaticMover` component.