### PR TITLE
Add lightning strike trigger

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -6,6 +6,13 @@ placements.entities.SpringCollab2020/diagonalWingedStrawberry.tooltips.checkpoin
 ﻿# Cave Wall
 placements.entities.SpringCollab2020/caveWall.tooltips.tiletype=Changes the visual appearance of the wall.
 
+# Lightning Strike Trigger
+placements.triggers.SpringCollab2020/LightningStrikeTrigger.tooltips.playerOffset=The X offset of the lightning relative to the player's position.
+placements.triggers.SpringCollab2020/LightningStrikeTrigger.tooltips.seed=The seed for the randomizer which generates the lightning strike.
+placements.triggers.SpringCollab2020/LightningStrikeTrigger.tooltips.delay=The delay, in seconds, between the player entering the trigger and the appearance of the lightning strike.
+placements.triggers.SpringCollab2020/LightningStrikeTrigger.tooltips.rain=Upon lightning strike, rain will begin falling in the level.
+placements.triggers.SpringCollab2020/LightningStrikeTrigger.tooltips.flash=Upon lightning strike, the screen will flash white.
+
 # Variable Crumble Blocks
 
 placements.entities.SpringCollab2020/variableCrumbleBlock.tooltips.texture=The texture of the blocks that are crumbling.2

--- a/Ahorn/triggers/lightningStrikeTrigger.jl
+++ b/Ahorn/triggers/lightningStrikeTrigger.jl
@@ -1,0 +1,14 @@
+﻿module SpringCollab2020LightningStrikeTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/LightningStrikeTrigger" LightningStrikeTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight, playerOffset::Number=0.0, seed::Integer=0, delay::Number=0.0, rain::Bool=true, flash::Bool=true)
+
+const placements = Ahorn.PlacementDict(
+    "Lightning Strike (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        LightningStrikeTrigger,
+        "rectangle",
+    ),
+)
+
+end

--- a/Triggers/LightningStrikeTrigger.cs
+++ b/Triggers/LightningStrikeTrigger.cs
@@ -8,7 +8,7 @@ using System.Collections;
 namespace Celeste.Mod.SpringCollab2020.Triggers {
     [CustomEntity("SpringCollab2020/LightningStrikeTrigger")]
     class LightningStrikeTrigger : Trigger {
-        public bool Activated { get; private set;
+        public bool Activated { get; private set; }
 
         private float PlayerOffset;
 

--- a/Triggers/LightningStrikeTrigger.cs
+++ b/Triggers/LightningStrikeTrigger.cs
@@ -1,0 +1,60 @@
+﻿using Celeste;
+using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using System.Linq;
+using Monocle;
+using System.Collections;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+    [CustomEntity("SpringCollab2020/LightningStrikeTrigger")]
+    class LightningStrikeTrigger : Trigger {
+        public LightningStrikeTrigger(EntityData data, Vector2 offset) : this(data, offset, data.Float("playerOffset", 0f), data.Int("seed", 0), data.Float("delay", 0f), data.Bool("rain", true), data.Bool("flash", true)) { }
+
+        public LightningStrikeTrigger(EntityData data, Vector2 offset, float playerOffset, int seed, float delay, bool raining, bool flash) : base (data, offset) {
+            PlayerOffset = playerOffset;
+            Seed = seed;
+            Delay = delay;
+            Raining = raining;
+            Flash = flash;
+        }
+
+        public override void OnEnter(Player player) {
+            base.OnEnter(player);
+
+            Level level = player.SceneAs<Level>();
+
+            if(!Activated) {
+                Activated = true;
+                level.Add(new LightningStrike(new Vector2(player.X + PlayerOffset, level.Bounds.Top), Seed, level.Bounds.Height, Delay));
+                Add(new Coroutine(ThunderEffect(level), true));
+
+                if(Raining && !level.Background.Backdrops.OfType<RainFG>().Any()) {
+                    level.Background.Backdrops.Add(new RainFG());
+                }
+            }
+        }
+
+        private IEnumerator ThunderEffect(Level level) {
+            yield return Delay;
+            Audio.Play("event:/new_content/game/10_farewell/lightning_strike");
+            level.Shake(0.3f);
+
+            if(Flash)
+                level.Flash(Color.White, false);
+
+            yield break;
+        }
+
+        public bool Activated { get; private set; }
+
+        private float PlayerOffset;
+
+        private int Seed;
+
+        private float Delay;
+
+        private bool Raining;
+
+        private bool Flash;
+    }
+}

--- a/Triggers/LightningStrikeTrigger.cs
+++ b/Triggers/LightningStrikeTrigger.cs
@@ -8,6 +8,18 @@ using System.Collections;
 namespace Celeste.Mod.SpringCollab2020.Triggers {
     [CustomEntity("SpringCollab2020/LightningStrikeTrigger")]
     class LightningStrikeTrigger : Trigger {
+        public bool Activated { get; private set;
+
+        private float PlayerOffset;
+
+        private int Seed;
+
+        private float Delay;
+
+        private bool Raining;
+
+        private bool Flash;
+    
         public LightningStrikeTrigger(EntityData data, Vector2 offset) : this(data, offset, data.Float("playerOffset", 0f), data.Int("seed", 0), data.Float("delay", 0f), data.Bool("rain", true), data.Bool("flash", true)) { }
 
         public LightningStrikeTrigger(EntityData data, Vector2 offset, float playerOffset, int seed, float delay, bool raining, bool flash) : base (data, offset) {
@@ -23,12 +35,12 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
 
             Level level = player.SceneAs<Level>();
 
-            if(!Activated) {
+            if (!Activated) {
                 Activated = true;
                 level.Add(new LightningStrike(new Vector2(player.X + PlayerOffset, level.Bounds.Top), Seed, level.Bounds.Height, Delay));
                 Add(new Coroutine(ThunderEffect(level), true));
 
-                if(Raining && !level.Background.Backdrops.OfType<RainFG>().Any()) {
+                if (Raining && !level.Background.Backdrops.OfType<RainFG>().Any()) {
                     level.Background.Backdrops.Add(new RainFG());
                 }
             }
@@ -39,22 +51,10 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
             Audio.Play("event:/new_content/game/10_farewell/lightning_strike");
             level.Shake(0.3f);
 
-            if(Flash)
+            if (Flash)
                 level.Flash(Color.White, false);
 
             yield break;
         }
-
-        public bool Activated { get; private set; }
-
-        private float PlayerOffset;
-
-        private int Seed;
-
-        private float Delay;
-
-        private bool Raining;
-
-        private bool Flash;
     }
 }


### PR DESCRIPTION
Adds a lightning strike trigger, which upon entering, creates a flash of lightning on the screen. There are also additional options:

- Add the rain ambience to the level, as initially requested (toggleable per trigger)
- Create a white flash on the screen when the lightning strikes (toggleable per trigger)
- X offset of the lightning relative to the player
- Delay for the lightning strike after entering the trigger
- The seed used to randomized the nodes/path of the lightning strike

Closes #4 