### PR TITLE
Madeline Silhouette Trigger

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -176,3 +176,6 @@ placements.entities.SpringCollab2020/MultiRoomStrawberry.tooltips.winged=The str
 placements.entities.SpringCollab2020/MultiRoomStrawberry.tooltips.checkpointID=Manually determine what checkpoint section strawberries are visually grouped up in, showing up on the start menu during gameplay and level select. Overrides Everest's automatic berry IDs. (Default= -1)
 placements.entities.SpringCollab2020/MultiRoomStrawberry.tooltips.order=Manually determine what order strawberries are visually placed in on the start menu during gameplay and level select. Overrides Everest's automatic berry IDs. (Default= -1)
 placements.entities.SpringCollab2020/MultiRoomStrawberry.tooltips.moon=Makes the strawberry render as a space berry.\nDoes not work with wings or nodes in the base game.
+
+# Madeline Silhouette Trigger
+placements.triggers.SpringCollab2020/MadelineSilhouetteTrigger.tooltips.enable=If checked, the trigger will turn Madeline into a silhouette. If unchecked, it will turn Madeline back to normal.

--- a/Ahorn/triggers/madelineSilhouetteTrigger.jl
+++ b/Ahorn/triggers/madelineSilhouetteTrigger.jl
@@ -1,0 +1,15 @@
+module SpringCollab2020MadelineSilhouetteTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/MadelineSilhouetteTrigger" MadelineSilhouetteTrigger(x::Integer, y::Integer, 
+    width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight, enable::Bool=true)
+
+const placements = Ahorn.PlacementDict(
+    "Madeline Silhouette (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        MadelineSilhouetteTrigger,
+        "rectangle"
+    )
+)
+
+end

--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -28,6 +28,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             FlagTouchSwitch.Load();
             DisableIcePhysicsTrigger.Load();
             MultiRoomStrawberrySeed.Load();
+            MadelineSilhouetteTrigger.Load();
         }
 
         public override void LoadContent(bool firstLoad) {
@@ -50,6 +51,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             FlagTouchSwitch.Unload();
             DisableIcePhysicsTrigger.Unload();
             MultiRoomStrawberrySeed.Unload();
+            MadelineSilhouetteTrigger.Unload();
         }
 
         public override void PrepareMapDataProcessors(MapDataFixup context) {

--- a/SpringCollab2020Session.cs
+++ b/SpringCollab2020Session.cs
@@ -13,5 +13,7 @@ namespace Celeste.Mod.SpringCollab2020 {
         public bool IcePhysicsDisabled { get; set; } = false;
 
         public List<MultiRoomStrawberrySeedInfo> CollectedMultiRoomStrawberrySeeds { get; set; } = new List<MultiRoomStrawberrySeedInfo>();
+
+        public bool MadelineIsSilhouette { get; set; } = false;
     }
 }

--- a/Triggers/MadelineSilhouetteTrigger.cs
+++ b/Triggers/MadelineSilhouetteTrigger.cs
@@ -1,0 +1,89 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Mono.Cecil.Cil;
+using Monocle;
+using MonoMod.Cil;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+    [CustomEntity("SpringCollab2020/MadelineSilhouetteTrigger")]
+    class MadelineSilhouetteTrigger : Trigger {
+        public static void Load() {
+            On.Celeste.Player.Added += onPlayerAdded;
+            IL.Celeste.Player.Render += patchPlayerRender;
+        }
+
+        public static void Unload() {
+            On.Celeste.Player.Added -= onPlayerAdded;
+            IL.Celeste.Player.Render -= patchPlayerRender;
+        }
+
+        private static void onPlayerAdded(On.Celeste.Player.orig_Added orig, Player self, Scene scene) {
+            if (SpringCollab2020Module.Instance.Session.MadelineIsSilhouette) {
+                refreshPlayerSpriteMode(self, true);
+            }
+
+            orig(self, scene);
+        }
+
+        private static void patchPlayerRender(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+
+            // jump to the usage of the White color
+            if (cursor.TryGotoNext(instr => instr.MatchCall<Color>("get_White"))) {
+                Logger.Log("SpringCollab2020/MadelineSilhouetteTrigger", $"Patching player color at {cursor.Index} in IL code for Player.Render()");
+
+                // instead of calling Color.White, call getMadelineColor just below.
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.Next.Operand = typeof(MadelineSilhouetteTrigger).GetMethod("GetMadelineColor");
+            }
+        }
+
+        public static Color GetMadelineColor(Player player) {
+            if (SpringCollab2020Module.Instance.Session.MadelineIsSilhouette) {
+                return player.Hair.Color;
+            } else {
+                return Color.White;
+            }
+        }
+
+        private static void refreshPlayerSpriteMode(Player player, bool enableSilhouette) {
+            PlayerSpriteMode targetSpriteMode;
+            if (enableSilhouette) {
+                targetSpriteMode = PlayerSpriteMode.Playback;
+            } else {
+                targetSpriteMode = SaveData.Instance.Assists.PlayAsBadeline ? PlayerSpriteMode.MadelineAsBadeline : player.DefaultSpriteMode;
+            }
+
+            if (player.Active) {
+                player.ResetSpriteNextFrame(targetSpriteMode);
+            } else {
+                player.ResetSprite(targetSpriteMode);
+            }
+        }
+
+
+        private bool enable;
+
+        public MadelineSilhouetteTrigger(EntityData data, Vector2 offset) : base(data, offset) {
+            enable = data.Bool("enable", true);
+        }
+
+        public override void OnEnter(Player player) {
+            base.OnEnter(player);
+
+            bool oldValue = SpringCollab2020Module.Instance.Session.MadelineIsSilhouette;
+            SpringCollab2020Module.Instance.Session.MadelineIsSilhouette = enable;
+
+            // if the value changed...
+            if (oldValue != enable) {
+                // switch modes right now. this uses the same way as turning the "Other Self" variant on.
+                refreshPlayerSpriteMode(player, enable);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #115.

Just a trigger turning Madeline into a tutorial ghost version of herself. There are missing sprites for some things, but this shouldn't matter for Bob Dole's map, because it relies on hard speed tech, so it has no swimming for example.