### PR TITLE
Rainbow Spinner Color Controller

### DIFF
--- a/Ahorn/entities/rainbowSpinnerColorController.jl
+++ b/Ahorn/entities/rainbowSpinnerColorController.jl
@@ -1,0 +1,22 @@
+module SpringCollab2020RainbowSpinnerColorController
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/RainbowSpinnerColorController" RainbowSpinnerColorController(x::Integer, y::Integer,
+    colors::String="89E5AE,88E0E0,87A9DD,9887DB,D088E2", gradientSize::Number=280.0)
+
+const placements = Ahorn.PlacementDict(
+    "Rainbow Spinner Colour Controller (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        RainbowSpinnerColorController
+    )
+)
+
+function Ahorn.selection(entity::RainbowSpinnerColorController)
+    x, y = Ahorn.position(entity)
+
+    return Ahorn.Rectangle(x - 12, y - 12, 24, 24)
+end
+
+Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::RainbowSpinnerColorController, room::Maple.Room) = Ahorn.drawImage(ctx, Ahorn.Assets.northernLights, -12, -12)
+
+end

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -179,3 +179,7 @@ placements.entities.SpringCollab2020/MultiRoomStrawberry.tooltips.moon=Makes the
 
 # Madeline Silhouette Trigger
 placements.triggers.SpringCollab2020/MadelineSilhouetteTrigger.tooltips.enable=If checked, the trigger will turn Madeline into a silhouette. If unchecked, it will turn Madeline back to normal.
+
+# Rainbow Spinner Color Controller
+placements.entities.SpringCollab2020/RainbowSpinnerColorController.tooltips.colors=The colours the rainbow spinners in the room will take, separated by commas. For example, if 3 colours A, B and C are specified, the colours will cycle in the following order: A > B > C > B > A.
+placements.entities.SpringCollab2020/RainbowSpinnerColorController.tooltips.gradientSize=The distance required to achieve a complete loop across all colours.

--- a/Entities/RainbowSpinnerColorController.cs
+++ b/Entities/RainbowSpinnerColorController.cs
@@ -1,0 +1,129 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    /// <summary>
+    /// A controller allowing for customization of rainbow spinner colors.
+    /// </summary>
+    [CustomEntity("SpringCollab2020/RainbowSpinnerColorController")]
+    class RainbowSpinnerColorController : Entity {
+        private static bool rainbowSpinnerHueHooked = false;
+
+        // the spinner controller on the current screen.
+        private static RainbowSpinnerColorController spinnerControllerOnScreen;
+
+        // during transitions: the spinner controller on the next screen, and the progress between both screens.
+        // transitionProgress = -1 means no transition is ongoing.
+        private static RainbowSpinnerColorController nextSpinnerController;
+        private static float transitionProgress = -1f;
+
+        // the parameters for this spinner controller.
+        private Color[] colors;
+        private float gradientSize;
+
+        public RainbowSpinnerColorController(EntityData data, Vector2 offset) : base(data.Position + offset) {
+            // convert the color list to Color objects
+            string[] colorsAsStrings = data.Attr("colors", "89E5AE,88E0E0,87A9DD,9887DB,D088E2").Split(',');
+            colors = new Color[colorsAsStrings.Length];
+            for (int i = 0; i < colors.Length; i++) {
+                colors[i] = Calc.HexToColor(colorsAsStrings[i]);
+            }
+
+            gradientSize = data.Float("gradientSize", 280);
+
+            Add(new TransitionListener {
+                OnIn = progress => transitionProgress = progress,
+                OnOut = progress => transitionProgress = progress,
+                OnInBegin = () => transitionProgress = 0f,
+                OnInEnd = () => transitionProgress = -1f
+            });
+        }
+
+        public override void Awake(Scene scene) {
+            base.Awake(scene);
+
+            // this is the controller for the next screen.
+            nextSpinnerController = this;
+
+            // enable the hook on rainbow spinner hue.
+            if (!rainbowSpinnerHueHooked) {
+                On.Celeste.CrystalStaticSpinner.GetHue += getRainbowSpinnerHue;
+                rainbowSpinnerHueHooked = true;
+            }
+        }
+
+        public override void Removed(Scene scene) {
+            base.Removed(scene);
+
+            // the "current" spinner controller is now the one from the next screen.
+            spinnerControllerOnScreen = nextSpinnerController;
+            nextSpinnerController = null;
+
+            // the transition (if any) is over.
+            transitionProgress = -1f;
+
+            // if there is none, clean up the hook on the spinner hue.
+            if (spinnerControllerOnScreen == null && rainbowSpinnerHueHooked) {
+                On.Celeste.CrystalStaticSpinner.GetHue -= getRainbowSpinnerHue;
+                rainbowSpinnerHueHooked = false;
+            }
+        }
+
+        public override void SceneEnd(Scene scene) {
+            base.SceneEnd(scene);
+
+            // leaving level: forget about all controllers and clean up the hook if present.
+            spinnerControllerOnScreen = null;
+            nextSpinnerController = null;
+            if (rainbowSpinnerHueHooked) {
+                On.Celeste.CrystalStaticSpinner.GetHue -= getRainbowSpinnerHue;
+                rainbowSpinnerHueHooked = false;
+            };
+        }
+
+        private static Color getRainbowSpinnerHue(On.Celeste.CrystalStaticSpinner.orig_GetHue orig, CrystalStaticSpinner self, Vector2 position) {
+            if (transitionProgress == -1f) {
+                // no transition is ongoing.
+                // if only nextSpinnerController is defined, move it into spinnerControllerOnScreen.
+                if (spinnerControllerOnScreen == null) {
+                    spinnerControllerOnScreen = nextSpinnerController;
+                    nextSpinnerController = null;
+                }
+
+                return getModHue(spinnerControllerOnScreen.colors, spinnerControllerOnScreen.gradientSize, self.Scene, self.Position);
+            } else {
+                // get the spinner color in the room we're coming from.
+                Color fromRoomColor;
+                if (spinnerControllerOnScreen != null) {
+                    fromRoomColor = getModHue(spinnerControllerOnScreen.colors, spinnerControllerOnScreen.gradientSize, self.Scene, self.Position);
+                } else {
+                    fromRoomColor = orig(self, position);
+                }
+
+                // get the spinner color in the room we're going to.
+                Color toRoomColor;
+                if (nextSpinnerController != null) {
+                    toRoomColor = getModHue(nextSpinnerController.colors, nextSpinnerController.gradientSize, self.Scene, self.Position);
+                } else {
+                    toRoomColor = orig(self, position);
+                }
+
+                // transition smoothly between both.
+                return Color.Lerp(fromRoomColor, toRoomColor, transitionProgress);
+            }
+        }
+
+        private static Color getModHue(Color[] colors, float gradientSize, Scene scene, Vector2 position) {
+            float progress = Calc.YoYo((position.Length() + scene.TimeActive * 50f) % gradientSize / gradientSize);
+            if (progress == 1) {
+                return colors[colors.Length - 1];
+            }
+
+            float globalProgress = (colors.Length - 1) * progress;
+            int colorIndex = (int) globalProgress;
+            float progressInIndex = globalProgress - colorIndex;
+            return Color.Lerp(colors[colorIndex], colors[colorIndex + 1], progressInIndex);
+        }
+    }
+}


### PR DESCRIPTION
Closes #69.

Drop a "rainbow spinner color controller" in a room with vanilla rainbow spinners to mod their color with a custom gradient.
If two controllers are present in two adjacent rooms with different parameters, spinners will fade between both parameters.

The CrystalStaticSpinner.GetHue is hooked on demand when a controller is loaded, and unhooked when the last controller is unloaded.

The default parameters attempt to emulate the gradient for vanilla spinners (which is a hue shift).