### PR TITLE
'Inverted' checkbox for flag-toggled entities

### DIFF
--- a/Ahorn/entities/flagToggleStarTrackSpinner.jl
+++ b/Ahorn/entities/flagToggleStarTrackSpinner.jl
@@ -2,8 +2,8 @@
 
 using ..Ahorn, Maple
 
-@pardef FlagToggleStarTrackSpinner(x1::Integer, y1::Integer, x2::Integer=x1 + 16, y2::Integer=y1, speed::String="Normal", startCenter::Bool=false, flag::String="flag_toggle_star_track_spinner") =
-    Entity("SpringCollab2020/FlagToggleStarTrackSpinner", x=x1, y=y1, nodes=Tuple{Int, Int}[(x2, y2)], speed=speed, startCenter=startCenter, flag=flag)
+@pardef FlagToggleStarTrackSpinner(x1::Integer, y1::Integer, x2::Integer=x1 + 16, y2::Integer=y1, speed::String="Normal", startCenter::Bool=false, flag::String="flag_toggle_star_track_spinner", inverted::Bool=false) =
+    Entity("SpringCollab2020/FlagToggleStarTrackSpinner", x=x1, y=y1, nodes=Tuple{Int, Int}[(x2, y2)], speed=speed, startCenter=startCenter, flag=flag, inverted=inverted)
 
 const placements = Ahorn.PlacementDict(
     "Star (Track, $(uppercasefirst(speed)), Flag Toggle) (Spring Collab 2020)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/flagToggleWater.jl
+++ b/Ahorn/entities/flagToggleWater.jl
@@ -3,7 +3,7 @@
 using ..Ahorn, Maple
 
 @mapdef Entity "SpringCollab2020/FlagToggleWater" FlagToggleWater(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight, hasBottom::Bool=false, flag::String="flag_toggle_water")
+    height::Integer=Maple.defaultBlockHeight, hasBottom::Bool=false, flag::String="flag_toggle_water", inverted::Bool=false)
 
 const placements = Ahorn.PlacementDict(
     "Flag Toggle Water (Spring Collab 2020)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/flagToggleWaterfall.jl
+++ b/Ahorn/entities/flagToggleWaterfall.jl
@@ -2,7 +2,7 @@
 
 using ..Ahorn, Maple
 
-@mapdef Entity "SpringCollab2020/FlagToggleWaterfall" FlagToggleWaterfall(x::Integer, y::Integer, flag::String="flag_toggle_waterfall")
+@mapdef Entity "SpringCollab2020/FlagToggleWaterfall" FlagToggleWaterfall(x::Integer, y::Integer, flag::String="flag_toggle_waterfall", inverted::Bool=false)
 
 const fillColor = Ahorn.XNAColors.LightBlue .* 0.3
 const surfaceColor = Ahorn.XNAColors.LightBlue .* 0.8

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -200,12 +200,15 @@ placements.entities.SpringCollab2020/RespawningJellyfish.tooltips.respawnTime=Th
 
 # Flag Toggle Water
 placements.entities.SpringCollab2020/FlagToggleWater.tooltips.hasBottom=Determines whether or not the water has a bottom.
-placements.entities.SpringCollab2020/FlagToggleWater.tooltips.flag=This entity will only appear if this flag is active.
+placements.entities.SpringCollab2020/FlagToggleWater.tooltips.flag=The flag this entity reacts to.
+placements.entities.SpringCollab2020/FlagToggleWater.tooltips.inverted=If checked, the entity will appear only if the flag is inactive.\nIf unchecked, the entity will appear only if the flag is active.
 
 # Flag Toggle Waterfall
-placements.entities.SpringCollab2020/FlagToggleWaterfall.tooltips.flag=This entity will only appear if this flag is active.
+placements.entities.SpringCollab2020/FlagToggleWaterfall.tooltips.flag=The flag this entity reacts to.
+placements.entities.SpringCollab2020/FlagToggleWaterfall.tooltips.inverted=If checked, the entity will appear only if the flag is inactive.\nIf unchecked, the entity will appear only if the flag is active.
 
 # Flag Toggle Star Track Spinner
 placements.entities.SpringCollab2020/FlagToggleStarTrackSpinner.tooltips.speed=Changes the speed of the spinner's rotation.
 placements.entities.SpringCollab2020/FlagToggleStarTrackSpinner.tooltips.startCenter=The spinner will start at the end of the track.
-placements.entities.SpringCollab2020/FlagToggleStarTrackSpinner.tooltips.flag=This entity will only appear if this flag is active.
+placements.entities.SpringCollab2020/FlagToggleStarTrackSpinner.tooltips.flag=The flag this entity reacts to.
+placements.entities.SpringCollab2020/FlagToggleStarTrackSpinner.tooltips.inverted=If checked, the entity will appear only if the flag is inactive.\nIf unchecked, the entity will appear only if the flag is active.

--- a/Entities/FlagToggleComponent.cs
+++ b/Entities/FlagToggleComponent.cs
@@ -10,9 +10,11 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
         private string flag;
         private Action onDisable;
         private Action onEnable;
+        private bool inverted;
 
-        public FlagToggleComponent(string flag, Action onDisable = null, Action onEnable = null) : base(true, false) {
+        public FlagToggleComponent(string flag, bool inverted, Action onDisable = null, Action onEnable = null) : base(true, false) {
             this.flag = flag;
+            this.inverted = inverted;
             this.onDisable = onDisable;
             this.onEnable = onEnable;
         }
@@ -20,7 +22,9 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
         public override void Update() {
             base.Update();
 
-            if (SceneAs<Level>().Session.GetFlag(flag) != Enabled) {
+            if ((!inverted && SceneAs<Level>().Session.GetFlag(flag) != Enabled)
+                || (inverted && SceneAs<Level>().Session.GetFlag(flag) == Enabled)) {
+
                 if (Enabled) {
                     // disable the entity.
                     Entity.Visible = Entity.Collidable = false;

--- a/Entities/FlagToggleStarTrackSpinner.cs
+++ b/Entities/FlagToggleStarTrackSpinner.cs
@@ -7,7 +7,7 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
         private FlagToggleComponent toggle;
 
         public FlagToggleStarTrackSpinner(EntityData data, Vector2 offset) : base(data, offset) {
-            Add(toggle = new FlagToggleComponent(data.Attr("flag")));
+            Add(toggle = new FlagToggleComponent(data.Attr("flag"), data.Bool("inverted")));
         }
 
         public override void Update() {

--- a/Entities/FlagToggleWater.cs
+++ b/Entities/FlagToggleWater.cs
@@ -19,7 +19,7 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             }
 
             // when the water is toggled, toggle the displacement as well.
-            Add(toggle = new FlagToggleComponent(data.Attr("flag"),
+            Add(toggle = new FlagToggleComponent(data.Attr("flag"), data.Bool("inverted"),
                 () => Remove(displacementHook), () => Add(displacementHook)));
         }
 

--- a/Entities/FlagToggleWaterfall.cs
+++ b/Entities/FlagToggleWaterfall.cs
@@ -13,7 +13,7 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
         private string enteringSfxEvent;
 
         public FlagToggleWaterfall(EntityData data, Vector2 offset) : base(data, offset) {
-            Add(toggle = new FlagToggleComponent(data.Attr("flag"), () => {
+            Add(toggle = new FlagToggleComponent(data.Attr("flag"), data.Bool("inverted"), () => {
                 // disable the waterfall sound.
                 loopingSfx.Stop();
                 enteringSfx.Stop();


### PR DESCRIPTION
Small request from Bissy on Discord: be able to make the flag-toggled entities _disappear_ when a flag is active. This is done via an "inverted" checkbox, that inverts the flag's logic.