### PR TITLE
Blue Torch that starts off lit

### DIFF
--- a/Ahorn/entities/litBlueTorch.jl
+++ b/Ahorn/entities/litBlueTorch.jl
@@ -1,0 +1,22 @@
+module SpringCollab2020LitBlueTorch
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/LitBlueTorch" LitBlueTorch(x::Integer, y::Integer)
+
+const placements = Ahorn.PlacementDict(
+    "Torch (Lit, Blue) (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        LitBlueTorch
+    )
+)
+
+sprite = "objects/temple/torch03"
+
+function Ahorn.selection(entity::LitBlueTorch)
+    x, y = Ahorn.position(entity)
+    return Ahorn.getSpriteRectangle(sprite, x, y)
+end
+
+Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::LitBlueTorch, room::Maple.Room) = Ahorn.drawSprite(ctx, sprite, 0, 0)
+
+end

--- a/Entities/LitBlueTorch.cs
+++ b/Entities/LitBlueTorch.cs
@@ -1,0 +1,18 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.Utils;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    [CustomEntity("SpringCollab2020/LitBlueTorch")]
+    class LitBlueTorch : Torch {
+        public LitBlueTorch(EntityData data, Vector2 offset, EntityID id) : base(data, offset, id) { }
+
+        public override void Added(Scene scene) {
+            // by turning on startLit in Added but not in the constructor, we make the torch blue instead of yellow.
+            new DynData<Torch>(this)["startLit"] = true;
+
+            base.Added(scene);
+        }
+    }
+}


### PR DESCRIPTION
Very small request from RealVet on Discord.

Torches in Temple have a `startLit` attribute, but that also makes them yellow. This one is blue. That's pretty much it.

That `startLit` attribute is checked twice: in the constructor to make it yellow, and in Added to light it right away and make it non-collidable. So, turning the attribute on at the beginning of `Added` does the trick.