### PR TITLE
Block Jelly Spawn Trigger

### DIFF
--- a/Ahorn/triggers/blockJellySpawnTrigger.jl
+++ b/Ahorn/triggers/blockJellySpawnTrigger.jl
@@ -1,0 +1,14 @@
+module SpringCollab2020BlockJellySpawnTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/BlockJellySpawnTrigger" BlockJellySpawnTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight)
+
+const placements = Ahorn.PlacementDict(
+    "Block Jelly Spawn (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        BlockJellySpawnTrigger,
+        "rectangle"
+    )
+)
+
+end

--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -29,6 +29,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             DisableIcePhysicsTrigger.Load();
             MultiRoomStrawberrySeed.Load();
             MadelineSilhouetteTrigger.Load();
+            BlockJellySpawnTrigger.Load();
         }
 
         public override void LoadContent(bool firstLoad) {
@@ -52,6 +53,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             DisableIcePhysicsTrigger.Unload();
             MultiRoomStrawberrySeed.Unload();
             MadelineSilhouetteTrigger.Unload();
+            BlockJellySpawnTrigger.Unload();
         }
 
         public override void PrepareMapDataProcessors(MapDataFixup context) {

--- a/Triggers/BlockJellySpawnTrigger.cs
+++ b/Triggers/BlockJellySpawnTrigger.cs
@@ -1,0 +1,33 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+using System.Linq;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+    [CustomEntity("SpringCollab2020/BlockJellySpawnTrigger")]
+    [Tracked]
+    class BlockJellySpawnTrigger : Trigger {
+        public static void Load() {
+            On.Celeste.Level.LoadLevel += onLoadLevel;
+        }
+
+        public static void Unload() {
+            On.Celeste.Level.LoadLevel -= onLoadLevel;
+        }
+
+        private static void onLoadLevel(On.Celeste.Level.orig_LoadLevel orig, Level self, Player.IntroTypes playerIntro, bool isFromLoader) {
+            orig(self, playerIntro, isFromLoader);
+
+            // if the player spawned in a Block Jelly Spawn Trigger...
+            if (playerIntro == Player.IntroTypes.Respawn && (self.Tracker.GetEntity<Player>()?.CollideCheck<BlockJellySpawnTrigger>() ?? false)) {
+                // remove all jellyfish from the room.
+                foreach (Glider jelly in self.Entities.OfType<Glider>()) {
+                    jelly.RemoveSelf();
+                }
+                self.Entities.UpdateLists();
+            }
+        }
+
+        public BlockJellySpawnTrigger(EntityData data, Vector2 offset) : base(data, offset) { }
+    }
+}


### PR DESCRIPTION
Closes #151.

That's a pretty specific request, but that's what DanTKO wants: when Madeline respawns inside one of those triggers, all jellies in the room shouldn't spawn. (they are actually removed right away, but the effect is the same.)