### PR TITLE
Add option to make glass block outlines appear behind fg tiles

### DIFF
--- a/Ahorn/entities/customizableGlassBlock.jl
+++ b/Ahorn/entities/customizableGlassBlock.jl
@@ -2,7 +2,7 @@ module SpringCollab2020CustomizableGlassBlock
 
 using ..Ahorn, Maple
 
-@mapdef Entity "SpringCollab2020/CustomizableGlassBlock" CustomizableGlassBlock(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight)
+@mapdef Entity "SpringCollab2020/CustomizableGlassBlock" CustomizableGlassBlock(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight, behindFgTiles::Bool=false)
 
 const placements = Ahorn.PlacementDict(
     "Customizable Glass Block (Spring Collab 2020)" => Ahorn.EntityPlacement(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -56,6 +56,9 @@ placements.triggers.SpringCollab2020/SmoothCameraOffsetTrigger.tooltips.onlyOnce
 # Dash Spring
 placements.entities.SpringCollab2020/dashSpring.tooltips.playerCanUse=Determines whether the player is able to interact with the spring.
 
+# Customizable Glass Block
+placements.entities.SpringCollab2020/CustomizableGlassBlock.tooltips.behindFgTiles=Whether the glass block outline should appear behind foreground tiles.
+
 # Customizable Glass Block Controller
 placements.entities.SpringCollab2020/CustomizableGlassBlockController.tooltips.starColors=A comma-separated list of all star colours visible in glass blocks in the room.
 placements.entities.SpringCollab2020/CustomizableGlassBlockController.tooltips.bgColor=The background colour for glass blocks in the room.

--- a/Entities/CustomizableGlassBlock.cs
+++ b/Entities/CustomizableGlassBlock.cs
@@ -24,17 +24,17 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
         private List<Line> lines = new List<Line>();
         private Color lineColor = Color.White;
 
-        public CustomizableGlassBlock(Vector2 position, float width, float height)
+        public CustomizableGlassBlock(Vector2 position, float width, float height, bool behindFgTiles)
             : base(position, width, height, safe: false) {
 
-            Depth = -10000;
+            Depth = behindFgTiles ? -9995 : -10000;
             Add(new LightOcclude());
             Add(new MirrorSurface());
             SurfaceSoundIndex = 32;
         }
 
         public CustomizableGlassBlock(EntityData data, Vector2 offset)
-            : this(data.Position + offset, data.Width, data.Height) { }
+            : this(data.Position + offset, data.Width, data.Height, data.Bool("behindFgTiles")) { }
 
         public override void Awake(Scene scene) {
             base.Awake(scene);


### PR DESCRIPTION
Requested by NeoKat (via direct ping to me) on Discord. The glass block background has depth -9990, fgtiles have depth -10000.