### PR TITLE
Fix bubbles disappearing early in left-facing bubble columns

### DIFF
--- a/Entities/BubblePushField.cs
+++ b/Entities/BubblePushField.cs
@@ -206,7 +206,7 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
                 case PushDirection.Left:
                     Origin = new Vector2(BubbleField.CenterRight.X, Rand.Range(BubbleField.BottomRight.Y, BubbleField.TopRight.Y));
                     End = new Vector2(BubbleField.CenterLeft.X, Rand.Range(BubbleField.BottomLeft.Y, BubbleField.TopLeft.Y));
-                    FramesMaxAlive = (int) Rand.Range(20, BubbleField.Height / BubbleField.Strength * .5f);
+                    FramesMaxAlive = (int) Rand.Range(20, BubbleField.Width / BubbleField.Strength * .5f);
                     break;
             }
 


### PR DESCRIPTION
Changes stupid mistake that causes bubbles to move and disappear based off the height of bubble columns rather than their width if they are left-facing.