### PR TITLE
Hide flag-toggled entities properly on transitions when flag is disabled

### DIFF
--- a/Entities/FlagToggleComponent.cs
+++ b/Entities/FlagToggleComponent.cs
@@ -21,7 +21,10 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
 
         public override void Update() {
             base.Update();
+            UpdateFlag();
+        }
 
+        public void UpdateFlag() {
             if ((!inverted && SceneAs<Level>().Session.GetFlag(flag) != Enabled)
                 || (inverted && SceneAs<Level>().Session.GetFlag(flag) == Enabled)) {
 

--- a/Entities/FlagToggleStarRotateSpinner.cs
+++ b/Entities/FlagToggleStarRotateSpinner.cs
@@ -1,5 +1,6 @@
 ﻿using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
+using Monocle;
 
 namespace Celeste.Mod.SpringCollab2020.Entities {
     [CustomEntity("SpringCollab2020/FlagToggleStarRotateSpinner")]
@@ -8,6 +9,11 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
 
         public FlagToggleStarRotateSpinner(EntityData data, Vector2 offset) : base(data, offset) {
             Add(toggle = new FlagToggleComponent(data.Attr("flag"), data.Bool("inverted")));
+        }
+
+        public override void Added(Scene scene) {
+            base.Added(scene);
+            toggle.UpdateFlag();
         }
 
         public override void Update() {

--- a/Entities/FlagToggleStarTrackSpinner.cs
+++ b/Entities/FlagToggleStarTrackSpinner.cs
@@ -1,5 +1,6 @@
 ﻿using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
+using Monocle;
 
 namespace Celeste.Mod.SpringCollab2020.Entities {
     [CustomEntity("SpringCollab2020/FlagToggleStarTrackSpinner")]
@@ -8,6 +9,11 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
 
         public FlagToggleStarTrackSpinner(EntityData data, Vector2 offset) : base(data, offset) {
             Add(toggle = new FlagToggleComponent(data.Attr("flag"), data.Bool("inverted")));
+        }
+
+        public override void Added(Scene scene) {
+            base.Added(scene);
+            toggle.UpdateFlag();
         }
 
         public override void Update() {

--- a/Entities/FlagToggleWaterfall.cs
+++ b/Entities/FlagToggleWaterfall.cs
@@ -33,6 +33,8 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             enteringSfx = self.Get<SoundSource>("enteringSfx");
             loopingSfxEvent = loopingSfx.EventName;
             enteringSfxEvent = enteringSfx.EventName;
+
+            toggle.UpdateFlag();
         }
 
         public override void Update() {


### PR DESCRIPTION
Spinners aren't updated at all during screen transitions, so we should hide them when they are added if we want to hide them during transitions.

Water and waterfalls are updated (they are tagged with TransitionUpdate), so water doesn't cause any issue. Waterfalls spawn some particles before they get disabled, so we need to turn them off early as well.