### PR TITLE
Seeker with custom particles and trail color

### DIFF
--- a/Ahorn/entities/seekerCustomColors.jl
+++ b/Ahorn/entities/seekerCustomColors.jl
@@ -1,0 +1,53 @@
+﻿module SpringCollab2020SeekerCustomColors
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/SeekerCustomColors" SeekerCustomColors(x::Integer, y::Integer, nodes::Array{Tuple{Integer, Integer}, 1}=Tuple{Integer, Integer}[],
+    attackParticleColor1::String="99e550", attackParticleColor2::String="ddffbc", regenParticleColor1::String="cbdbfc", regenParticleColor2::String="575fd9", trailColor::String="99e550")
+
+const placements = Ahorn.PlacementDict(
+    "Seeker (Custom Colors) (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        SeekerCustomColors,
+        "point",
+        Dict{String, Any}(),
+        function(entity)
+            entity.data["nodes"] = [(Int(entity.data["x"]) + 32, Int(entity.data["y"]))]
+        end
+    )
+)
+
+Ahorn.nodeLimits(entity::SeekerCustomColors) = 1, -1
+
+function Ahorn.selection(entity::SeekerCustomColors)
+    nodes = get(entity.data, "nodes", ())
+    x, y = Ahorn.position(entity)
+
+    res = Ahorn.Rectangle[Ahorn.getSpriteRectangle(sprite, x, y)]
+    
+    for node in nodes
+        nx, ny = node
+
+        push!(res, Ahorn.getSpriteRectangle(sprite, nx, ny))
+    end
+
+    return res
+end
+
+sprite = "characters/monsters/predator73.png"
+
+function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::SeekerCustomColors)
+    px, py = Ahorn.position(entity)
+
+    for node in get(entity.data, "nodes", ())
+        nx, ny = Int.(node)
+
+        Ahorn.drawArrow(ctx, px, py, nx, ny, Ahorn.colors.selection_selected_fc, headLength=6)
+        Ahorn.drawSprite(ctx, sprite, nx, ny)
+
+        px, py = nx, ny
+    end
+end
+
+Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::SeekerCustomColors, room::Maple.Room) = Ahorn.drawSprite(ctx, sprite, 0, 0)
+
+end

--- a/Ahorn/entities/seekerStatueCustomColors.jl
+++ b/Ahorn/entities/seekerStatueCustomColors.jl
@@ -1,0 +1,59 @@
+﻿module SpringCollab2020SeekerStatueCustomColors
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/SeekerStatueCustomColors" SeekerStatueCustomColors(x::Integer, y::Integer, hatch::String="Distance", nodes::Array{Tuple{Integer, Integer}, 1}=Tuple{Integer, Integer}[],
+    breakOutParticleColor1::String="643e73", breakOutParticleColor2::String="3e2854", attackParticleColor1::String="99e550", attackParticleColor2::String="ddffbc",
+    regenParticleColor1::String="cbdbfc", regenParticleColor2::String="575fd9", trailColor::String="99e550")
+
+const placements = Ahorn.PlacementDict(
+    "Seeker Statue (Custom Colors) (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        SeekerStatueCustomColors,
+        "point",
+        Dict{String, Any}(),
+        function(entity)
+            entity.data["nodes"] = [(Int(entity.data["x"]) + 32, Int(entity.data["y"]))]
+        end
+    )
+)
+
+Ahorn.nodeLimits(entity::SeekerStatueCustomColors) = 1, -1
+
+Ahorn.editingOptions(entity::SeekerStatueCustomColors) = Dict{String, Any}(
+    "hatch" => Maple.seeker_statue_hatches
+)
+
+function Ahorn.selection(entity::SeekerStatueCustomColors)
+    nodes = get(entity.data, "nodes", ())
+    x, y = Ahorn.position(entity)
+
+    res = Ahorn.Rectangle[Ahorn.getSpriteRectangle(statueSprite, x, y)]
+    
+    for node in nodes
+        nx, ny = node
+
+        push!(res, Ahorn.getSpriteRectangle(monsterSprite, nx, ny))
+    end
+
+    return res
+end
+
+statueSprite = "decals/5-temple/statue_e.png"
+monsterSprite = "characters/monsters/predator73.png"
+
+function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::SeekerStatueCustomColors)
+    px, py = Ahorn.position(entity)
+
+    for node in get(entity.data, "nodes", ())
+        nx, ny = Int.(node)
+
+        Ahorn.drawArrow(ctx, px, py, nx, ny, Ahorn.colors.selection_selected_fc, headLength=6)
+        Ahorn.drawSprite(ctx, monsterSprite, nx, ny)
+
+        px, py = nx, ny
+    end
+end
+
+Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::SeekerStatueCustomColors, room::Maple.Room) = Ahorn.drawSprite(ctx, statueSprite, 0, 0)
+
+end

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -247,3 +247,20 @@ placements.entities.SpringCollab2020/NegativeSummitCheckpoint.tooltips.number=Ch
 # Remove Light Sources Trigger
 placements.triggers.SpringCollab2020/RemoveLightSourcesTrigger.tooltips.enableLightSources=If checked, this trigger will re-enable light sources instead of disabling them.
 placements.triggers.SpringCollab2020/RemoveLightSourcesTrigger.tooltips.fade=If checked, the lights will fade in or out.
+
+# Seeker (Custom Colors)
+placements.entities.SpringCollab2020/SeekerCustomColors.tooltips.attackParticleColor1=The first color of the particles the seeker emits when attacking.
+placements.entities.SpringCollab2020/SeekerCustomColors.tooltips.attackParticleColor2=The second color of the particles the seeker emits when attacking.
+placements.entities.SpringCollab2020/SeekerCustomColors.tooltips.regenParticleColor1=The first color of the particles the seeker emits when respawning.
+placements.entities.SpringCollab2020/SeekerCustomColors.tooltips.regenParticleColor2=The second color of the particles the seeker emits when respawning.
+placements.entities.SpringCollab2020/SeekerCustomColors.tooltips.trailColor=The color of the trail the seeker leaves behind it when "dashing".
+
+# Seeker Statue (Custom Colors)
+placements.entities.SpringCollab2020/SeekerStatueCustomColors.tooltips.hatch=Determines whether the statue releases its seeker when the player is to the right of it, or when the player gets close enough.
+placements.entities.SpringCollab2020/SeekerStatueCustomColors.tooltips.breakOutParticleColor1=The first color of the particles the seeker emits when breaking out of the statue.
+placements.entities.SpringCollab2020/SeekerStatueCustomColors.tooltips.breakOutParticleColor2=The second color of the particles the seeker emits when breaking out of the statue.
+placements.entities.SpringCollab2020/SeekerStatueCustomColors.tooltips.attackParticleColor1=The first color of the particles the seeker emits when attacking.
+placements.entities.SpringCollab2020/SeekerStatueCustomColors.tooltips.attackParticleColor2=The second color of the particles the seeker emits when attacking.
+placements.entities.SpringCollab2020/SeekerStatueCustomColors.tooltips.regenParticleColor1=The first color of the particles the seeker emits when respawning.
+placements.entities.SpringCollab2020/SeekerStatueCustomColors.tooltips.regenParticleColor2=The second color of the particles the seeker emits when respawning.
+placements.entities.SpringCollab2020/SeekerStatueCustomColors.tooltips.trailColor=The color of the trail the seeker leaves behind it when "dashing".

--- a/Entities/SeekerCustomColors.cs
+++ b/Entities/SeekerCustomColors.cs
@@ -1,0 +1,70 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.Utils;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    [CustomEntity("SpringCollab2020/SeekerCustomColors")]
+    [TrackedAs(typeof(Seeker))]
+    class SeekerCustomColors : Seeker {
+        private static ParticleType basePAttack;
+        private static ParticleType basePHitWall;
+        private static ParticleType basePStomp;
+        private static ParticleType basePRegen;
+        private static Color baseTrailColor;
+
+        private ParticleType pAttack; // blinks between 99e550 and ddffbc
+        private ParticleType pHitWall; // blinks between 99e550 and ddffbc (same as Attack)
+        private ParticleType pStomp; // copies pAttack
+        private ParticleType pRegen; // blinks between cbdbfc and 575fd9
+        private Color trailColor;
+
+        private DynData<Seeker> self;
+
+        public SeekerCustomColors(EntityData data, Vector2 offset) : base(data, offset) {
+            if (basePAttack == null) {
+                basePAttack = P_Attack;
+                basePHitWall = P_HitWall;
+                basePStomp = P_Stomp;
+                basePRegen = P_Regen;
+                baseTrailColor = TrailColor;
+            }
+
+            pAttack = new ParticleType(P_Attack) {
+                Color = Calc.HexToColor(data.Attr("attackParticleColor1")),
+                Color2 = Calc.HexToColor(data.Attr("attackParticleColor2"))
+            };
+            pHitWall = new ParticleType(P_HitWall) {
+                Color = Calc.HexToColor(data.Attr("attackParticleColor1")),
+                Color2 = Calc.HexToColor(data.Attr("attackParticleColor2"))
+            };
+            pStomp = new ParticleType(P_Stomp) {
+                Color = Calc.HexToColor(data.Attr("attackParticleColor1")),
+                Color2 = Calc.HexToColor(data.Attr("attackParticleColor2"))
+            };
+            pRegen = new ParticleType(P_Regen) {
+                Color = Calc.HexToColor(data.Attr("regenParticleColor1")),
+                Color2 = Calc.HexToColor(data.Attr("regenParticleColor2"))
+            };
+            trailColor = Calc.HexToColor(data.Attr("trailColor"));
+
+            self = new DynData<Seeker>(this);
+        }
+
+        public override void Update() {
+            P_Attack = pAttack;
+            P_HitWall = pHitWall;
+            P_Stomp = pStomp;
+            P_Regen = pRegen;
+            self["TrailColor"] = trailColor;
+
+            base.Update();
+
+            P_Attack = basePAttack;
+            P_HitWall = basePHitWall;
+            P_Stomp = basePStomp;
+            P_Regen = basePRegen;
+            self["TrailColor"] = baseTrailColor;
+        }
+    }
+}

--- a/Entities/SeekerStatueCustomColors.cs
+++ b/Entities/SeekerStatueCustomColors.cs
@@ -1,0 +1,36 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.Utils;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    [CustomEntity("SpringCollab2020/SeekerStatueCustomColors")]
+    class SeekerStatueCustomColors : SeekerStatue {
+        private static ParticleType basePBreakOut;
+        private ParticleType pBreakOut; // chooses between 643e73 and 3e2854
+
+        public SeekerStatueCustomColors(EntityData data, Vector2 offset) : base(data, offset) {
+            if (basePBreakOut == null) {
+                basePBreakOut = Seeker.P_BreakOut;
+            }
+
+            pBreakOut = new ParticleType(Seeker.P_BreakOut) {
+                Color = Calc.HexToColor(data.Attr("breakOutParticleColor1")),
+                Color2 = Calc.HexToColor(data.Attr("breakOutParticleColor2"))
+            };
+
+            new DynData<SeekerStatue>(this).Get<Sprite>("sprite").OnLastFrame = anim => {
+                if (anim == "hatch") {
+                    Scene.Add(new SeekerCustomColors(data, offset) { Light = { Alpha = 0f } });
+                    RemoveSelf();
+                }
+            };
+        }
+
+        public override void Update() {
+            Seeker.P_BreakOut = pBreakOut;
+            base.Update();
+            Seeker.P_BreakOut = basePBreakOut;
+        }
+    }
+}


### PR DESCRIPTION
Request from TheAdvertisement on Discord.

Basically, particles are static attributes used when the seeker is updated. Those modded seekers swap out vanilla particles with custom colored counterparts at the beginning of their Update() method, and places them back at the end. This is enough to mod those particles' colors while not impacting other seekers (multiple, vanilla and modded, can be on-screen at the same time).