### PR TITLE
Underwater Switch Controller: Fix 'Madeline coming out of water' sound effect when respawning underwater

### DIFF
--- a/Entities/UnderwaterSwitchController.cs
+++ b/Entities/UnderwaterSwitchController.cs
@@ -16,16 +16,16 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             flag = data.Attr("flag");
 
             Add(new Coroutine(Routine()));
+        }
 
-            Add(new TransitionListener() {
-                OnInBegin = () => {
-                    // when transitioning in a room with a controller and the flag is already set, spawn water right away
-                    Session session = SceneAs<Level>().Session;
-                    if (session.GetFlag(flag)) {
-                        spawnWater(session.LevelData.Bounds);
-                    }
-                }
-            });
+        public override void Added(Scene scene) {
+            base.Added(scene);
+
+            // if the flag is already set, spawn water right away
+            Session session = SceneAs<Level>().Session;
+            if (session.GetFlag(flag)) {
+                spawnWater(session.LevelData.Bounds);
+            }
         }
 
         public IEnumerator Routine() {


### PR DESCRIPTION
Madeline was briefly coming out of water when respawning: there was no water between the respawn and the first time the underwater switch controller got updated.

To fix this, water gets spawned in the underwater switch controller's Added method if the flag is already active when it spawns.