### PR TITLE
Refill with custom respawn time

### DIFF
--- a/Ahorn/entities/customRespawnTimeRefill.jl
+++ b/Ahorn/entities/customRespawnTimeRefill.jl
@@ -1,0 +1,42 @@
+﻿module SpringCollab2020CustomRespawnTimeRefill
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/CustomRespawnTimeRefill" CustomRespawnTimeRefill(x::Integer, y::Integer, twoDash::Bool=false, respawnTime::Number=2.5)
+
+const placements = Ahorn.PlacementDict(
+    "Refill (Custom Respawn Time) (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        CustomRespawnTimeRefill
+    ),
+
+    "Refill (Two Dashes, Custom Respawn Time) (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        CustomRespawnTimeRefill,
+        "point",
+        Dict{String, Any}(
+            "twoDash" => true
+        )
+    )
+)
+
+spriteOneDash = "objects/refill/idle00"
+spriteTwoDash = "objects/refillTwo/idle00"
+
+function getSprite(entity::CustomRespawnTimeRefill)
+    twoDash = get(entity.data, "twoDash", false)
+
+    return twoDash ? spriteTwoDash : spriteOneDash
+end
+
+function Ahorn.selection(entity::CustomRespawnTimeRefill)
+    x, y = Ahorn.position(entity)
+    sprite = getSprite(entity)
+
+    return Ahorn.getSpriteRectangle(sprite, x, y)
+end
+
+function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::CustomRespawnTimeRefill, room::Maple.Room)
+    sprite = getSprite(entity)
+    Ahorn.drawSprite(ctx, sprite, 0, 0)
+end
+
+end

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -264,3 +264,7 @@ placements.entities.SpringCollab2020/SeekerStatueCustomColors.tooltips.attackPar
 placements.entities.SpringCollab2020/SeekerStatueCustomColors.tooltips.regenParticleColor1=The first color of the particles the seeker emits when respawning.
 placements.entities.SpringCollab2020/SeekerStatueCustomColors.tooltips.regenParticleColor2=The second color of the particles the seeker emits when respawning.
 placements.entities.SpringCollab2020/SeekerStatueCustomColors.tooltips.trailColor=The color of the trail the seeker leaves behind it when "dashing".
+
+# Custom Respawn Time Refill
+placements.entities.SpringCollab2020/CustomRespawnTimeRefill.tooltips.twoDash=Whether the refill should give two dashes.
+placements.entities.SpringCollab2020/CustomRespawnTimeRefill.tooltips.respawnTime=The delay (in seconds) before the refill respawns after being collected.

--- a/Entities/CustomRespawnTimeRefill.cs
+++ b/Entities/CustomRespawnTimeRefill.cs
@@ -1,0 +1,28 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.Utils;
+using System;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    [CustomEntity("SpringCollab2020/CustomRespawnTimeRefill")]
+    class CustomRespawnTimeRefill : Refill {
+        public CustomRespawnTimeRefill(EntityData data, Vector2 offset) : base(data, offset) {
+            DynData<Refill> self = new DynData<Refill>(this);
+            float respawnTime = data.Float("respawnTime", 2.5f);
+
+            foreach (Component component in this) {
+                if (component is PlayerCollider collider) {
+                    // wrap the original OnPlayer method to modify the respawnTimer if it gets reset to 2.5f.
+                    Action<Player> orig = collider.OnCollide;
+                    collider.OnCollide = player => {
+                        orig(player);
+                        if (self.Get<float>("respawnTimer") == 2.5f) {
+                            self["respawnTimer"] = respawnTime;
+                        }
+                    };
+                }
+            }
+        }
+    }
+}

--- a/Entities/CustomRespawnTimeRefill.cs
+++ b/Entities/CustomRespawnTimeRefill.cs
@@ -11,18 +11,15 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             DynData<Refill> self = new DynData<Refill>(this);
             float respawnTime = data.Float("respawnTime", 2.5f);
 
-            foreach (Component component in this) {
-                if (component is PlayerCollider collider) {
-                    // wrap the original OnPlayer method to modify the respawnTimer if it gets reset to 2.5f.
-                    Action<Player> orig = collider.OnCollide;
-                    collider.OnCollide = player => {
-                        orig(player);
-                        if (self.Get<float>("respawnTimer") == 2.5f) {
-                            self["respawnTimer"] = respawnTime;
-                        }
-                    };
+            // wrap the original OnPlayer method to modify the respawnTimer if it gets reset to 2.5f.
+            PlayerCollider collider = Get<PlayerCollider>();
+            Action<Player> orig = collider.OnCollide;
+            collider.OnCollide = player => {
+                orig(player);
+                if (self.Get<float>("respawnTimer") == 2.5f) {
+                    self["respawnTimer"] = respawnTime;
                 }
-            }
+            };
         }
     }
 }


### PR DESCRIPTION
This works the same as a vanilla refill, except the respawn time is different. This differs from "Plus One Refill" from Frost Helper (which has a custom respawn time too) because Plus One Refill is capped to the player's max dashes, unlike the vanilla double refills.