### PR TITLE
Rainbow Spinner Color Area Controller

### DIFF
--- a/Ahorn/entities/rainbowSpinnerColorAreaController.jl
+++ b/Ahorn/entities/rainbowSpinnerColorAreaController.jl
@@ -1,0 +1,27 @@
+module SpringCollab2020RainbowSpinnerColorAreaController
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/RainbowSpinnerColorAreaController" RainbowSpinnerColorAreaController(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
+    colors::String="89E5AE,88E0E0,87A9DD,9887DB,D088E2", gradientSize::Number=280.0)
+
+const placements = Ahorn.PlacementDict(
+    "Rainbow Spinner Colour Area Controller (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        RainbowSpinnerColorAreaController,
+        "rectangle"
+    )
+)
+
+Ahorn.minimumSize(entity::RainbowSpinnerColorAreaController) = 8, 8
+Ahorn.resizable(entity::RainbowSpinnerColorAreaController) = true, true
+
+Ahorn.selection(entity::RainbowSpinnerColorAreaController) = Ahorn.getEntityRectangle(entity)
+
+function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::RainbowSpinnerColorAreaController, room::Maple.Room)
+    width = Int(get(entity.data, "width", 32))
+    height = Int(get(entity.data, "height", 32))
+
+    Ahorn.drawRectangle(ctx, 0, 0, width, height, (0.4, 0.4, 1.0, 0.4), (0.4, 0.4, 1.0, 1.0))
+end
+
+end

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -203,6 +203,10 @@ placements.triggers.SpringCollab2020/MadelineSilhouetteTrigger.tooltips.enable=I
 placements.entities.SpringCollab2020/RainbowSpinnerColorController.tooltips.colors=The colours the rainbow spinners in the room will take, separated by commas. For example, if 3 colours A, B and C are specified, the colours will cycle in the following order: A > B > C > B > A.
 placements.entities.SpringCollab2020/RainbowSpinnerColorController.tooltips.gradientSize=The distance required to achieve a complete loop across all colours.
 
+# Rainbow Spinner Color Area Controller
+placements.entities.SpringCollab2020/RainbowSpinnerColorAreaController.tooltips.colors=The colours the rainbow spinners in the area will take, separated by commas. For example, if 3 colours A, B and C are specified, the colours will cycle in the following order: A > B > C > B > A.
+placements.entities.SpringCollab2020/RainbowSpinnerColorAreaController.tooltips.gradientSize=The distance required to achieve a complete loop across all colours.
+
 # Music Layer Fade Trigger
 placements.triggers.SpringCollab2020/MusicLayerFadeTrigger.tooltips.layers=Which layers the trigger should change.
 placements.triggers.SpringCollab2020/MusicLayerFadeTrigger.tooltips.fadeA=The first volume for the music layer.

--- a/Entities/RainbowSpinnerColorAreaController.cs
+++ b/Entities/RainbowSpinnerColorAreaController.cs
@@ -1,0 +1,70 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    [CustomEntity("SpringCollab2020/RainbowSpinnerColorAreaController")]
+    [Tracked]
+    class RainbowSpinnerColorAreaController : Entity {
+        private static bool rainbowSpinnerHueHooked = false;
+
+        // the parameters for this spinner controller.
+        private Color[] colors;
+        private float gradientSize;
+
+        public RainbowSpinnerColorAreaController(EntityData data, Vector2 offset) : base(data.Position + offset) {
+            // convert the color list to Color objects
+            string[] colorsAsStrings = data.Attr("colors", "89E5AE,88E0E0,87A9DD,9887DB,D088E2").Split(',');
+            colors = new Color[colorsAsStrings.Length];
+            for (int i = 0; i < colors.Length; i++) {
+                colors[i] = Calc.HexToColor(colorsAsStrings[i]);
+            }
+
+            gradientSize = data.Float("gradientSize", 280);
+
+            // make this controller collidable.
+            Collider = new Hitbox(data.Width, data.Height);
+        }
+
+        public override void Awake(Scene scene) {
+            base.Awake(scene);
+
+            // enable the hook on rainbow spinner hue.
+            if (!rainbowSpinnerHueHooked) {
+                On.Celeste.CrystalStaticSpinner.GetHue += getRainbowSpinnerHue;
+                rainbowSpinnerHueHooked = true;
+            }
+        }
+
+        public override void Removed(Scene scene) {
+            base.Removed(scene);
+
+            // if this controller was the last in the scene, disable the hook on rainbow spinner hue.
+            if (rainbowSpinnerHueHooked && scene.Tracker.CountEntities<RainbowSpinnerColorAreaController>() <= 1) {
+                On.Celeste.CrystalStaticSpinner.GetHue -= getRainbowSpinnerHue;
+                rainbowSpinnerHueHooked = false;
+            }
+        }
+
+        public override void SceneEnd(Scene scene) {
+            base.SceneEnd(scene);
+
+            // leaving level; disable the hook on rainbow spinner hue.
+            if (rainbowSpinnerHueHooked) {
+                On.Celeste.CrystalStaticSpinner.GetHue -= getRainbowSpinnerHue;
+                rainbowSpinnerHueHooked = false;
+            };
+        }
+
+        private static Color getRainbowSpinnerHue(On.Celeste.CrystalStaticSpinner.orig_GetHue orig, CrystalStaticSpinner self, Vector2 position) {
+            RainbowSpinnerColorAreaController controller = self.CollideFirst<RainbowSpinnerColorAreaController>();
+            if (controller != null) {
+                // apply the color from the controller we are in.
+                return RainbowSpinnerColorController.getModHue(controller.colors, controller.gradientSize, self.Scene, position);
+            } else {
+                // we are not in a controller; apply the vanilla color.
+                return orig(self, position);
+            }
+        }
+    }
+}

--- a/Entities/RainbowSpinnerColorController.cs
+++ b/Entities/RainbowSpinnerColorController.cs
@@ -114,7 +114,7 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             }
         }
 
-        private static Color getModHue(Color[] colors, float gradientSize, Scene scene, Vector2 position) {
+        internal static Color getModHue(Color[] colors, float gradientSize, Scene scene, Vector2 position) {
             float progress = Calc.YoYo((position.Length() + scene.TimeActive * 50f) % gradientSize / gradientSize);
             if (progress == 1) {
                 return colors[colors.Length - 1];


### PR DESCRIPTION
Same principle as Rainbow Spinner Color Controller, but controlling spinners colliding with the area of the controller.

This was made into a separate entity, since
- the controller is room-wide and is point-based, the area controller is rectangle-based
- the controller has some logic to fade the spinner colors if two successive rooms have different settings, which is not required here: we just want the spinners within an area to have a certain color.