### PR TITLE
Add a disableTransitionFading attribute to Cave Walls

### DIFF
--- a/Ahorn/entities/caveWall.jl
+++ b/Ahorn/entities/caveWall.jl
@@ -2,7 +2,8 @@ module SpringCollab2020CaveWall
 
 using ..Ahorn, Maple
 
-@mapdef Entity "SpringCollab2020/caveWall" CaveWall(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight, tiletype::String="3")
+@mapdef Entity "SpringCollab2020/caveWall" CaveWall(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
+    tiletype::String="3", disableTransitionFading::Bool=false)
 
 const placements = Ahorn.PlacementDict(
     "Cave Wall (Spring Collab 2020)" => Ahorn.EntityPlacement(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -21,6 +21,7 @@ placements.entities.SpringCollab2020/LightningDashSwitch.tooltips.persistent=Whe
 
 ﻿# Cave Wall
 placements.entities.SpringCollab2020/caveWall.tooltips.tiletype=Changes the visual appearance of the wall.
+placements.entities.SpringCollab2020/caveWall.tooltips.disableTransitionFading=If ticked, prevents the wall from fading in during transitions.
 
 # Lightning Strike Trigger
 placements.triggers.SpringCollab2020/LightningStrikeTrigger.tooltips.playerOffset=The X offset of the lightning relative to the player's position.

--- a/Entities/CaveWall.cs
+++ b/Entities/CaveWall.cs
@@ -11,6 +11,7 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
     public class CaveWall : Entity {
 
         private char fillTile;
+        private bool disableTransitionFading;
 
         private TileGrid tiles;
 
@@ -43,16 +44,17 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             private set;
         }
 
-        public CaveWall(Vector2 position, char tile, float width, float height)
+        public CaveWall(Vector2 position, char tile, float width, float height, bool disableTransitionFading)
             : base(position) {
             fillTile = tile;
+            this.disableTransitionFading = disableTransitionFading;
             Collider = new Hitbox(width, height);
             Depth = -13001;
             Add(cutout = new EffectCutout());
         }
 
         public CaveWall(EntityData data, Vector2 offset)
-            : this(data.Position + offset, data.Char("tiletype", '3'), data.Width, data.Height) {
+            : this(data.Position + offset, data.Char("tiletype", '3'), data.Width, data.Height, data.Bool("disableTransitionFading", false)) {
         }
 
         public override void Awake(Scene scene) {
@@ -102,12 +104,14 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
                 cutout.Visible = false;
             }
 
-            TransitionListener transitionListener = new TransitionListener();
-            transitionListener.OnOut = OnTransitionOut;
-            transitionListener.OnOutBegin = OnTransitionOutBegin;
-            transitionListener.OnIn = OnTransitionIn;
-            transitionListener.OnInBegin = OnTransitionInBegin;
-            Add(transitionListener);
+            if (!disableTransitionFading) {
+                TransitionListener transitionListener = new TransitionListener();
+                transitionListener.OnOut = OnTransitionOut;
+                transitionListener.OnOutBegin = OnTransitionOutBegin;
+                transitionListener.OnIn = OnTransitionIn;
+                transitionListener.OnInBegin = OnTransitionInBegin;
+                Add(transitionListener);
+            }
         }
 
         private void TryToInitPosition() {


### PR DESCRIPTION
Per Cruor's request, add an option to prevent Cave Walls from fading in or out during transitions.