### PR TITLE
Turn on jumpthru hooks only in maps containing them

### DIFF
--- a/Entities/SidewaysJumpThru.cs
+++ b/Entities/SidewaysJumpThru.cs
@@ -291,6 +291,13 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             : this(data.Position + offset, data.Height, !data.Bool("left"), data.Attr("texture", "default"), data.Float("animationDelay", 0f)) {
         }
 
+        public override void Added(Scene scene) {
+            base.Added(scene);
+
+            // if hooks weren't activated yet somehow, activate them now.
+            activateHooks();
+        }
+
         public override void Awake(Scene scene) {
             if (animationDelay > 0f) {
                 for (int i = 0; i < lines; i++) {

--- a/Entities/UpsideDownJumpThru.cs
+++ b/Entities/UpsideDownJumpThru.cs
@@ -339,6 +339,13 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             Collider.Top += 3;
         }
 
+        public override void Added(Scene scene) {
+            base.Added(scene);
+
+            // if hooks weren't activated yet somehow, activate them now.
+            activateHooks();
+        }
+
         public override void Awake(Scene scene) {
             if (animationDelay > 0f) {
                 for (int i = 0; i < columns; i++) {


### PR DESCRIPTION
Directional jumpthrus are heavy on IL patches. And if people (uhhh myself for example) want to extract those jumpthrus into a helper, the IL patches conflict between each other.

A good solution (imo) for those conflicts would be that both patches don't get applied at the same time. Since collab jumpthrus are only to be used in the collab, both types of jumpthrus (collab ones + "public" ones) cannot be used in the same map. So, activating the hooks when entering a map with those jumpthrus will fix conflicts between helpers.

This PR checks if a map uses jumpthrus in order to enable them. For more performance this can be replaced later by, for example, a map SID check, when we will start tidying the collab mod structure.