### PR TITLE
Custom Bird Tutorial: adjust width and height of bubble more accurately

### DIFF
--- a/Entities/CustomBirdTutorial.cs
+++ b/Entities/CustomBirdTutorial.cs
@@ -47,7 +47,6 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             }
 
             int extraAdvance = 0;
-            bool firstIsString = false;
 
             // go ahead and parse the controls. Controls can be textures, VirtualButtons, directions or strings.
             string[] controlsStrings = data.Attr("controls").Split(',');
@@ -71,7 +70,9 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
                         // width computation doesn't take this 1px into account, so we should add it back in.
                         extraAdvance++;
                         if (i == 0) {
-                            firstIsString = true;
+                            // as the text is rendered 1px to the right, if the first thing is a string, there will be 1px more padding on the left.
+                            // we should add that extra px on the right as well.
+                            extraAdvance++;
                         }
 
                         if (controlString.StartsWith("dialog:")) {
@@ -91,11 +92,6 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             // if there is no first line, resize the bubble accordingly.
             if (string.IsNullOrEmpty(infoString)) {
                 guiData["infoHeight"] = 0f;
-            }
-            // as the text is rendered 1px to the right, if the first thing is a string, there will be 1px padding on the left.
-            // we should add that extra px on the right as well.
-            if (firstIsString) {
-                extraAdvance++;
             }
             // apply the extra width.
             guiData["controlsWidth"] = guiData.Get<float>("controlsWidth") + extraAdvance;


### PR DESCRIPTION
2 things in one:
- if the info text is empty, shrink the bubble to only have it have 1 line of text.
![image](https://user-images.githubusercontent.com/52103563/80276836-76fdc300-86eb-11ea-9cdb-d623c9da55c2.png)
- when the bubble width is computed, every text part in controls counts for the text width. But, when it is rendered, the text is offset by 1px on the right, and actually makes the following be offset by the text width **+ 1**. The more text parts are used, the more that offset is visible (here each "A" is a separate text part):
![image](https://user-images.githubusercontent.com/52103563/80277063-c55f9180-86ec-11ea-8c14-f50b6b1aae81.png)
To compensate, this PR adds 1 to the bubble width for each text part. 1 more pixel is added if the first part is a text part, so that the bigger padding on the left is applied on the right as well.

This fix will be copied to Everest if this is merged here.