### PR TITLE
Fix flag toggle waterfall crash when used with underwater switch controller

### DIFF
--- a/Entities/FlagToggleWaterfall.cs
+++ b/Entities/FlagToggleWaterfall.cs
@@ -12,6 +12,8 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
         private string loopingSfxEvent;
         private string enteringSfxEvent;
 
+        private bool alreadyTurnedOnOnce = false;
+
         public FlagToggleWaterfall(EntityData data, Vector2 offset) : base(data, offset) {
             Add(toggle = new FlagToggleComponent(data.Attr("flag"), data.Bool("inverted"), () => {
                 // disable the waterfall sound.
@@ -35,10 +37,42 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
             enteringSfxEvent = enteringSfx.EventName;
 
             toggle.UpdateFlag();
+
+            if (toggle.Enabled) {
+                alreadyTurnedOnOnce = true;
+            }
         }
 
         public override void Update() {
             if (toggle.Enabled) {
+                // if we are turning the waterfall on for the first time, compute its height, now that other entities
+                // (pools of water, underwater switch controller) have been toggled to match as well.
+                if (!alreadyTurnedOnOnce) {
+                    DynData<WaterFall> self = new DynData<WaterFall>(this);
+                    float height = 8f;
+                    Water water = null;
+                    Solid solid = null;
+                    while (Y + height < SceneAs<Level>().Bounds.Bottom
+                        && (water = Scene.CollideFirst<Water>(new Rectangle((int) X, (int) (Y + height), 8, 8))) == null
+                        && ((solid = Scene.CollideFirst<Solid>(new Rectangle((int) X, (int) (Y + height), 8, 8))) == null || !solid.BlockWaterfalls)) {
+
+                        height += 8f;
+                        solid = null;
+                    }
+                    if (water != null && !Scene.CollideCheck<Solid>(new Rectangle((int) X, (int) (Y + height), 8, 16))) {
+                        enteringSfxEvent = "event:/env/local/waterfall_small_in_deep";
+                    } else {
+                        enteringSfxEvent = "event:/env/local/waterfall_small_in_shallow";
+                    }
+                    enteringSfx.Play(enteringSfxEvent);
+
+                    self["height"] = height;
+                    self["water"] = water;
+                    self["solid"] = solid;
+
+                    alreadyTurnedOnOnce = true;
+                }
+
                 // update the entity as usual
                 base.Update();
             } else {

--- a/Entities/UnderwaterSwitchController.cs
+++ b/Entities/UnderwaterSwitchController.cs
@@ -47,6 +47,7 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
                 }
 
                 // make water go away.
+                water.Collidable = false;
                 Scene.Remove(water);
                 water = null;
             }


### PR DESCRIPTION
There was a crash in this specific case:
- when waterfall spawns, the whole level is underwater (underwater switch controller), so the waterfall is "hitting" that water
- you hit a switch, making the waterfall appear and making the level not underwater anymore
- the waterfall wants to spawn particles on top of the water spawned by the underwater switch controller, since it is hitting it
- crash because it has no top

This PR works around that by computing the height / associated water pool when the waterfall is first turned on. In this situation, that means that the water spawned by the underwater switch controller is turned off when this computation occurs, and as such won't interfere.