### PR TITLE
Color Grade Fade Trigger: fade between 2 color grades

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -18,7 +18,6 @@ placements.entities.SpringCollab2020/LightningDashSwitch.tooltips.side=Which dir
 placements.entities.SpringCollab2020/LightningDashSwitch.tooltips.sprite=Changes the visual appearance of the switch.
 placements.entities.SpringCollab2020/LightningDashSwitch.tooltips.persistent=Whether or not the switch will stay pressed upon leaving the room.
 
-
 ﻿# Cave Wall
 placements.entities.SpringCollab2020/caveWall.tooltips.tiletype=Changes the visual appearance of the wall.
 placements.entities.SpringCollab2020/caveWall.tooltips.disableTransitionFading=If ticked, prevents the wall from fading in during transitions.
@@ -279,3 +278,8 @@ placements.entities.SpringCollab2020/CustomRespawnTimeRefill.tooltips.respawnTim
 
 # Camera Catchup Speed Trigger
 placements.triggers.SpringCollab2020/CameraCatchupSpeedTrigger.tooltips.catchupSpeed=Raise this value to have the camera scroll quicker to its target. Vanilla values are 8 during the temple fall cutscene, and 1 everywhere else.
+
+# Color Grade Fade Trigger
+placements.triggers.SpringCollab2020/ColorGradeFadeTrigger.tooltips.colorGradeA=The color grade to fade from.
+placements.triggers.SpringCollab2020/ColorGradeFadeTrigger.tooltips.colorGradeB=The color grade to fade to.
+placements.triggers.SpringCollab2020/ColorGradeFadeTrigger.tooltips.direction=The direction of the fade. For example, if set to LeftToRight, the color grade will fade from color grade A to color grade B when the player crosses the trigger from left to right.

--- a/Ahorn/triggers/colorGradeFadeTrigger.jl
+++ b/Ahorn/triggers/colorGradeFadeTrigger.jl
@@ -1,0 +1,25 @@
+module SpringCollab2020ColorGradeFadeTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/ColorGradeFadeTrigger" ColorGradeFadeTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
+    colorGradeA::String="none", colorGradeB::String="none", direction::String="LeftToRight")
+
+const placements = Ahorn.PlacementDict(
+    "Color Grade Fade (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        ColorGradeFadeTrigger,
+        "rectangle",
+    ),
+)
+
+const colorGrades = String["none", "oldsite", "panicattack", "templevoid", "reflection", "credits", "cold", "hot", "feelingdown", "golden"]
+
+function Ahorn.editingOptions(trigger::ColorGradeFadeTrigger)
+    return Dict{String, Any}(
+        "direction" => String["LeftToRight", "TopToBottom"],
+        "colorGradeA" => colorGrades,
+        "colorGradeB" => colorGrades
+    )
+end
+
+end

--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -33,6 +33,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             StrawberryIgnoringLighting.Load();
             SeekerCustomColors.Load();
             CameraCatchupSpeedTrigger.Load();
+            ColorGradeFadeTrigger.Load();
         }
 
         public override void LoadContent(bool firstLoad) {
@@ -61,6 +62,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             StrawberryIgnoringLighting.Unload();
             SeekerCustomColors.Unload();
             CameraCatchupSpeedTrigger.Unload();
+            ColorGradeFadeTrigger.Unload();
         }
 
         public override void PrepareMapDataProcessors(MapDataFixup context) {

--- a/Triggers/ColorGradeFadeTrigger.cs
+++ b/Triggers/ColorGradeFadeTrigger.cs
@@ -1,0 +1,56 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.Utils;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+    [CustomEntity("SpringCollab2020/ColorGradeFadeTrigger")]
+    [Tracked]
+    class ColorGradeFadeTrigger : Trigger {
+        public static void Load() {
+            On.Celeste.Level.Update += onLevelUpdate;
+        }
+
+        public static void Unload() {
+            On.Celeste.Level.Update -= onLevelUpdate;
+        }
+
+        private static void onLevelUpdate(On.Celeste.Level.orig_Update orig, Level self) {
+            orig(self);
+
+            // check if the player is in a color grade fade trigger
+            Player player = self.Tracker.GetEntity<Player>();
+            ColorGradeFadeTrigger trigger;
+            if (player != null && (trigger = player.CollideFirst<ColorGradeFadeTrigger>()) != null) {
+                DynData<Level> selfData = new DynData<Level>(self);
+
+                // the game fades from lastColorGrade to Session.ColorGrade using colorGradeEase as a lerp value.
+                // let's hijack that!
+                float positionLerp = trigger.GetPositionLerp(player, trigger.direction);
+                if (positionLerp > 0.5f) {
+                    // we are closer to B. let B be the target color grade when player exits the trigger / dies in it
+                    selfData["lastColorGrade"] = trigger.colorGradeA;
+                    self.Session.ColorGrade = trigger.colorGradeB;
+                    selfData["colorGradeEase"] = MathHelper.Clamp(positionLerp, 0.001f, 0.999f);
+                } else {
+                    // we are closer to A. let A be the target color grade when player exits the trigger / dies in it
+                    selfData["lastColorGrade"] = trigger.colorGradeB;
+                    self.Session.ColorGrade = trigger.colorGradeA;
+                    selfData["colorGradeEase"] = MathHelper.Clamp(1 - positionLerp, 0.001f, 0.999f);
+                }
+                selfData["colorGradeEaseSpeed"] = 1f;
+            }
+        }
+
+
+        private string colorGradeA;
+        private string colorGradeB;
+        private PositionModes direction;
+
+        public ColorGradeFadeTrigger(EntityData data, Vector2 offset) : base(data, offset) {
+            colorGradeA = data.Attr("colorGradeA");
+            colorGradeB = data.Attr("colorGradeB");
+            direction = data.Enum<PositionModes>("direction");
+        }
+    }
+}

--- a/Triggers/ColorGradeFadeTrigger.cs
+++ b/Triggers/ColorGradeFadeTrigger.cs
@@ -20,8 +20,8 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
 
             // check if the player is in a color grade fade trigger
             Player player = self.Tracker.GetEntity<Player>();
-            ColorGradeFadeTrigger trigger;
-            if (player != null && (trigger = player.CollideFirst<ColorGradeFadeTrigger>()) != null) {
+            ColorGradeFadeTrigger trigger = player?.CollideFirst<ColorGradeFadeTrigger>();
+            if (trigger != null) {
                 DynData<Level> selfData = new DynData<Level>(self);
 
                 // the game fades from lastColorGrade to Session.ColorGrade using colorGradeEase as a lerp value.
@@ -31,12 +31,12 @@ namespace Celeste.Mod.SpringCollab2020.Triggers {
                     // we are closer to B. let B be the target color grade when player exits the trigger / dies in it
                     selfData["lastColorGrade"] = trigger.colorGradeA;
                     self.Session.ColorGrade = trigger.colorGradeB;
-                    selfData["colorGradeEase"] = MathHelper.Clamp(positionLerp, 0.001f, 0.999f);
+                    selfData["colorGradeEase"] = positionLerp;
                 } else {
                     // we are closer to A. let A be the target color grade when player exits the trigger / dies in it
                     selfData["lastColorGrade"] = trigger.colorGradeB;
                     self.Session.ColorGrade = trigger.colorGradeA;
-                    selfData["colorGradeEase"] = MathHelper.Clamp(1 - positionLerp, 0.001f, 0.999f);
+                    selfData["colorGradeEase"] = 1 - positionLerp;
                 }
                 selfData["colorGradeEaseSpeed"] = 1f;
             }


### PR DESCRIPTION
Requested by Linj on Discord.

This works by hijacking the game's own "fade between 2 color grades" mechanic when transitioning from a color grade to another (normally happens when using `Level.NextColorGrade`). Except we are controlling the lerp value ourselves depending on the player position.