### PR TITLE
Heat Wave effect not affecting color grade when disabled

### DIFF
--- a/Ahorn/effects/heatWaveNoColorGrade.jl
+++ b/Ahorn/effects/heatWaveNoColorGrade.jl
@@ -1,0 +1,13 @@
+﻿module SpringCollab2020HeatWaveNoColorGrade
+
+using ..Ahorn, Maple
+
+@mapdef Effect "SpringCollab2020/HeatWaveNoColorGrade" HeatWaveNoColorGrade(only::String="*", exclude::String="")
+
+placements = HeatWaveNoColorGrade
+
+function Ahorn.canFgBg(effect::HeatWaveNoColorGrade)
+    return true, true
+end
+
+end

--- a/Effects/HeatWaveNoColorGrade.cs
+++ b/Effects/HeatWaveNoColorGrade.cs
@@ -1,0 +1,46 @@
+﻿using Monocle;
+using MonoMod.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.SpringCollab2020.Effects {
+    /// <summary>
+    /// A heatwave effect that does not affect the colorgrade when it is hidden.
+    /// </summary>
+    class HeatWaveNoColorGrade : HeatWave {
+        private DynData<HeatWave> self = new DynData<HeatWave>();
+
+        public HeatWaveNoColorGrade() : base() {
+            self = new DynData<HeatWave>(this);
+        }
+
+        public override void Update(Scene scene) {
+            Level level = scene as Level;
+            bool show = (IsVisible(level) && level.CoreMode != Session.CoreModes.None);
+
+            if (!show) {
+                // if not fading out, the heatwave is invisible, so don't even bother updating it.
+                if (self.Get<float>("fade") > 0) {
+                    // be sure to lock color grading to prevent it from becoming "none".
+                    DynData<Level> levelData = new DynData<Level>(level);
+
+                    float colorGradeEase = levelData.Get<float>("colorGradeEase");
+                    float colorGradeEaseSpeed = levelData.Get<float>("colorGradeEaseSpeed");
+                    string colorGrade = level.Session.ColorGrade;
+
+                    base.Update(scene);
+
+                    levelData["colorGradeEase"] = colorGradeEase;
+                    levelData["colorGradeEaseSpeed"] = colorGradeEaseSpeed;
+                    level.Session.ColorGrade = colorGrade;
+                }
+            } else {
+                // heat wave is visible: update as usual.
+                base.Update(scene);
+            }
+        }
+    }
+}

--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -1,3 +1,4 @@
+using Celeste.Mod.SpringCollab2020.Effects;
 using Celeste.Mod.SpringCollab2020.Entities;
 using Celeste.Mod.SpringCollab2020.Triggers;
 using System;
@@ -34,6 +35,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             SeekerCustomColors.Load();
             CameraCatchupSpeedTrigger.Load();
             ColorGradeFadeTrigger.Load();
+            Everest.Events.Level.OnLoadBackdrop += onLoadBackdrop;
         }
 
         public override void LoadContent(bool firstLoad) {
@@ -63,6 +65,14 @@ namespace Celeste.Mod.SpringCollab2020 {
             SeekerCustomColors.Unload();
             CameraCatchupSpeedTrigger.Unload();
             ColorGradeFadeTrigger.Unload();
+            Everest.Events.Level.OnLoadBackdrop -= onLoadBackdrop;
+        }
+
+        private Backdrop onLoadBackdrop(MapData map, BinaryPacker.Element child, BinaryPacker.Element above) {
+            if (child.Name.Equals("SpringCollab2020/HeatWaveNoColorGrade", StringComparison.OrdinalIgnoreCase)) {
+                return new HeatWaveNoColorGrade();
+            }
+            return null;
         }
 
         public override void PrepareMapDataProcessors(MapDataFixup context) {


### PR DESCRIPTION
A quite... specific request. For lobbies, it would be quite handy to have a heatwave effect that doesn't always mess with the color grade. The vanilla heatwave effect forces the color grade to "none" if it is not visible.

This PR adds a heatwave effect that is just the vanilla one, except it forces the colorgrade not to be changed by vanilla heatwave when it is fading out, and skips updating entirely (so the colorgrade is not changed) when the heatwave is invisible.