### PR TITLE
Speed-Based Music Param Trigger

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -283,3 +283,9 @@ placements.triggers.SpringCollab2020/CameraCatchupSpeedTrigger.tooltips.catchupS
 placements.triggers.SpringCollab2020/ColorGradeFadeTrigger.tooltips.colorGradeA=The color grade to fade from.
 placements.triggers.SpringCollab2020/ColorGradeFadeTrigger.tooltips.colorGradeB=The color grade to fade to.
 placements.triggers.SpringCollab2020/ColorGradeFadeTrigger.tooltips.direction=The direction of the fade. For example, if set to LeftToRight, the color grade will fade from color grade A to color grade B when the player crosses the trigger from left to right.
+
+# Speed-Based Music Param Trigger
+placements.triggers.SpringCollab2020/SpeedBasedMusicParamTrigger.tooltips.paramName=The name of the music parameter to change.
+placements.triggers.SpringCollab2020/SpeedBasedMusicParamTrigger.tooltips.minSpeed=The minimum value the music parameter can take.
+placements.triggers.SpringCollab2020/SpeedBasedMusicParamTrigger.tooltips.maxSpeed=The maximum value the music parameter can take.
+placements.triggers.SpringCollab2020/SpeedBasedMusicParamTrigger.tooltips.activate=If ticked, the trigger will start adjusting the music parameter to match the player's speed.\nIf unticked, the trigger will stop adjusting that music parameter, and set it to minSpeed.

--- a/Ahorn/triggers/speedBasedMusicParamTrigger.jl
+++ b/Ahorn/triggers/speedBasedMusicParamTrigger.jl
@@ -1,0 +1,15 @@
+module SpringCollab2020SpeedBasedMusicParamTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/SpeedBasedMusicParamTrigger" SpeedBasedMusicParamTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
+    paramName::String="fade", minSpeed::Number=0.0, maxSpeed::Number=1.0, activate::Bool=true)
+
+const placements = Ahorn.PlacementDict(
+    "Speed-Based Music Param (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        SpeedBasedMusicParamTrigger,
+        "rectangle"
+    )
+)
+
+end

--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -36,6 +36,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             SeekerCustomColors.Load();
             CameraCatchupSpeedTrigger.Load();
             ColorGradeFadeTrigger.Load();
+            SpeedBasedMusicParamTrigger.Load();
             Everest.Events.Level.OnLoadBackdrop += onLoadBackdrop;
 
             DecalRegistry.AddPropertyHandler("scale", (decal, attrs) => {
@@ -77,6 +78,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             SeekerCustomColors.Unload();
             CameraCatchupSpeedTrigger.Unload();
             ColorGradeFadeTrigger.Unload();
+            SpeedBasedMusicParamTrigger.Unload();
             Everest.Events.Level.OnLoadBackdrop -= onLoadBackdrop;
         }
 

--- a/SpringCollab2020Session.cs
+++ b/SpringCollab2020Session.cs
@@ -17,5 +17,12 @@ namespace Celeste.Mod.SpringCollab2020 {
         public bool MadelineIsSilhouette { get; set; } = false;
 
         public bool LightSourcesDisabled { get; set; } = false;
+
+        public class SpeedBasedMusicParamInfo {
+            public float MinimumSpeed { get; set; }
+            public float MaximumSpeed { get; set; }
+        }
+
+        public Dictionary<string, SpeedBasedMusicParamInfo> ActiveSpeedBasedMusicParams = new Dictionary<string, SpeedBasedMusicParamInfo>();
     }
 }

--- a/Triggers/SpeedBasedMusicParamTrigger.cs
+++ b/Triggers/SpeedBasedMusicParamTrigger.cs
@@ -1,0 +1,63 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+    [CustomEntity("SpringCollab2020/SpeedBasedMusicParamTrigger")]
+    class SpeedBasedMusicParamTrigger : Trigger {
+        public static void Load() {
+            On.Celeste.Player.Update += onPlayerUpdate;
+        }
+
+        public static void Unload() {
+            On.Celeste.Player.Update -= onPlayerUpdate;
+        }
+
+        private static void onPlayerUpdate(On.Celeste.Player.orig_Update orig, Player self) {
+            orig(self);
+
+            AudioState audio = self.SceneAs<Level>().Session.Audio;
+            float playerSpeed = self.Speed.Length();
+
+            // set all the speed-based music params to their corresponding values.
+            foreach (KeyValuePair<string, SpringCollab2020Session.SpeedBasedMusicParamInfo> musicParam
+                in SpringCollab2020Module.Instance.Session.ActiveSpeedBasedMusicParams) {
+
+                audio.Music.Param(musicParam.Key, MathHelper.Clamp(playerSpeed, musicParam.Value.MinimumSpeed, musicParam.Value.MaximumSpeed));
+            }
+
+            audio.Apply();
+        }
+
+        private string paramName;
+        private float minSpeed;
+        private float maxSpeed;
+        private bool activate;
+
+        public SpeedBasedMusicParamTrigger(EntityData data, Vector2 offset) : base(data, offset) {
+            paramName = data.Attr("paramName");
+            minSpeed = data.Float("minSpeed");
+            maxSpeed = data.Float("maxSpeed");
+            activate = data.Bool("activate");
+        }
+
+        public override void OnEnter(Player player) {
+            base.OnEnter(player);
+
+            if (activate) {
+                // register the speed-based music param as active to keep it updated.
+                SpringCollab2020Module.Instance.Session.ActiveSpeedBasedMusicParams[paramName] = new SpringCollab2020Session.SpeedBasedMusicParamInfo() {
+                    MinimumSpeed = minSpeed,
+                    MaximumSpeed = maxSpeed
+                };
+            } else {
+                // unregister the param, and set the music param to the minimum value.
+                SpringCollab2020Module.Instance.Session.ActiveSpeedBasedMusicParams.Remove(paramName);
+
+                AudioState audio = SceneAs<Level>().Session.Audio;
+                audio.Music.Param(paramName, minSpeed);
+                audio.Apply();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Request from Thegur90:

> the ideal scenario is a trigger which has:
2 numeric values - maximum and minimum.
fmod parameter textbox
activate/deactivate checkbox
>
> when on activate:
the trigger will constantly get the speed value of maddy and output it to the fmod param. on my end ill set the fmod parameter values to match the speed.
if it's outside the min/max value boundary it will output the min/max values respectively.
>
> when on deactivate:
the trigger will output the minimum value all the time.
>
> all effects should work until you touch another trigger, as having a giant trigger on the entire map isn't ideal.

This PR is... pretty much that.