### PR TITLE
Flag-toggled camera target triggers and smooth camera offsets

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -58,6 +58,25 @@ placements.triggers.SpringCollab2020/SmoothCameraOffsetTrigger.tooltips.offsetYT
 placements.triggers.SpringCollab2020/SmoothCameraOffsetTrigger.tooltips.positionMode=The fade direction.
 placements.triggers.SpringCollab2020/SmoothCameraOffsetTrigger.tooltips.onlyOnce=If checked, the trigger will be disabled when the player first leaves it.
 
+# Flag Toggle Smooth Camera Offset Trigger
+placements.triggers.SpringCollab2020/FlagToggleSmoothCameraOffsetTrigger.tooltips.offsetXFrom=The X offset to fade from.
+placements.triggers.SpringCollab2020/FlagToggleSmoothCameraOffsetTrigger.tooltips.offsetXTo=The X offset to fade to.
+placements.triggers.SpringCollab2020/FlagToggleSmoothCameraOffsetTrigger.tooltips.offsetYFrom=The Y offset to fade from.
+placements.triggers.SpringCollab2020/FlagToggleSmoothCameraOffsetTrigger.tooltips.offsetYTo=The Y offset to fade to.
+placements.triggers.SpringCollab2020/FlagToggleSmoothCameraOffsetTrigger.tooltips.positionMode=The fade direction.
+placements.triggers.SpringCollab2020/FlagToggleSmoothCameraOffsetTrigger.tooltips.onlyOnce=If checked, the trigger will be disabled when the player first leaves it.
+placements.triggers.SpringCollab2020/FlagToggleSmoothCameraOffsetTrigger.tooltips.flag=The flag this trigger should react to.
+placements.triggers.SpringCollab2020/FlagToggleSmoothCameraOffsetTrigger.tooltips.inverted=If checked, the trigger will be disabled when the flag is active.\nIf unchecked, the trigger will be enabled when the flag is active.
+
+# Flag Toggle Camera Target Trigger
+placements.triggers.SpringCollab2020/FlagToggleCameraTargetTrigger.tooltips.positionMode=Determines which direction the camera position moves in.
+placements.triggers.SpringCollab2020/FlagToggleCameraTargetTrigger.tooltips.yOnly=The camera will only lock on the Y axis.
+placements.triggers.SpringCollab2020/FlagToggleCameraTargetTrigger.tooltips.xOnly=The camera will only lock on the X axis.
+placements.triggers.SpringCollab2020/FlagToggleCameraTargetTrigger.tooltips.lerpStrength=Determines how fast the camera moves to lock into place upon activation.
+placements.triggers.SpringCollab2020/FlagToggleCameraTargetTrigger.tooltips.deleteFlag=Session flag to deactivate the trigger, ignored if left empty. Camera will not reset if player is inside the trigger as it deactivates.\nIf the player transitions into the room with the flag set, the trigger can not be reactivated. However, if it was enabled and then disabled in the room, the player can reactivate it.
+placements.triggers.SpringCollab2020/FlagToggleCameraTargetTrigger.tooltips.flag=The flag this trigger should react to.
+placements.triggers.SpringCollab2020/FlagToggleCameraTargetTrigger.tooltips.inverted=If checked, the trigger will be disabled when the flag is active.\nIf unchecked, the trigger will be enabled when the flag is active.
+
 # Dash Spring
 placements.entities.SpringCollab2020/dashSpring.tooltips.playerCanUse=Determines whether the player is able to interact with the spring.
 

--- a/Ahorn/triggers/flagToggleCameraTargetTrigger.jl
+++ b/Ahorn/triggers/flagToggleCameraTargetTrigger.jl
@@ -1,0 +1,30 @@
+module SpringCollab2020FlagToggleCameraTargetTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/FlagToggleCameraTargetTrigger" FlagToggleCameraTargetTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
+    lerpStrength::Number=0.0, positionMode::String="NoEffect", xOnly::Bool=false, yOnly::Bool=false, deleteFlag::String="", nodes::Array{Tuple{Integer, Integer}, 1}=Tuple{Integer, Integer}[],
+    flag::String="flag_toggle_camera_target", inverted::Bool=false)
+
+const placements = Ahorn.PlacementDict(
+    "Flag Toggle Camera Target (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        FlagToggleCameraTargetTrigger,
+        "rectangle",
+        Dict{String, Any}(),
+        function(trigger)
+            trigger.data["nodes"] = [(Int(trigger.data["x"]) + Int(trigger.data["width"]) + 8, Int(trigger.data["y"]))]
+        end
+    )
+)
+
+function Ahorn.editingOptions(trigger::FlagToggleCameraTargetTrigger)
+    return Dict{String, Any}(
+        "positionMode" => Maple.trigger_position_modes
+    )
+end
+
+function Ahorn.nodeLimits(trigger::FlagToggleCameraTargetTrigger)
+    return 1, 1
+end
+
+end

--- a/Ahorn/triggers/flagToggleSmoothCameraOffsetTrigger.jl
+++ b/Ahorn/triggers/flagToggleSmoothCameraOffsetTrigger.jl
@@ -1,0 +1,21 @@
+module SpringCollab2020FlagToggleSmoothCameraOffsetTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/FlagToggleSmoothCameraOffsetTrigger" FlagToggleSmoothCameraOffsetTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
+    offsetXFrom::Number=0.0, offsetXTo::Number=0.0, offsetYFrom::Number=0.0, offsetYTo::Number=0.0, positionMode::String="NoEffect", onlyOnce::Bool=false, flag::String="flag_toggle_smooth_camera_offset", inverted::Bool=false)
+
+const placements = Ahorn.PlacementDict(
+    "Flag Toggle Smooth Camera Offset (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        FlagToggleSmoothCameraOffsetTrigger,
+        "rectangle",
+    ),
+)
+
+function Ahorn.editingOptions(trigger::FlagToggleSmoothCameraOffsetTrigger)
+    return Dict{String, Any}(
+        "positionMode" => Maple.trigger_position_modes
+    )
+end
+
+end

--- a/Triggers/FlagToggleCameraTargetTrigger.cs
+++ b/Triggers/FlagToggleCameraTargetTrigger.cs
@@ -1,0 +1,12 @@
+﻿using Celeste.Mod.Entities;
+using Celeste.Mod.SpringCollab2020.Entities;
+using Microsoft.Xna.Framework;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+    [CustomEntity("SpringCollab2020/FlagToggleCameraTargetTrigger")]
+    class FlagToggleCameraTargetTrigger : CameraTargetTrigger {
+        public FlagToggleCameraTargetTrigger(EntityData data, Vector2 offset) : base(data, offset) {
+            Add(new FlagToggleComponent(data.Attr("flag"), data.Bool("inverted")));
+        }
+    }
+}

--- a/Triggers/FlagToggleSmoothCameraOffsetTrigger.cs
+++ b/Triggers/FlagToggleSmoothCameraOffsetTrigger.cs
@@ -1,0 +1,12 @@
+﻿using Celeste.Mod.Entities;
+using Celeste.Mod.SpringCollab2020.Entities;
+using Microsoft.Xna.Framework;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+    [CustomEntity("SpringCollab2020/FlagToggleSmoothCameraOffsetTrigger")]
+    class FlagToggleSmoothCameraOffsetTrigger : SmoothCameraOffsetTrigger {
+        public FlagToggleSmoothCameraOffsetTrigger(EntityData data, Vector2 offset) : base(data, offset) {
+            Add(new FlagToggleComponent(data.Attr("flag"), data.Bool("inverted")));
+        }
+    }
+}


### PR DESCRIPTION
For special use cases in lobbies. Since smooth offsets can be used as regular ones as well, I didn't make a "flag toggled camera offset trigger".