### PR TITLE
Static Puffer

### DIFF
--- a/Ahorn/entities/staticPuffer.jl
+++ b/Ahorn/entities/staticPuffer.jl
@@ -1,0 +1,39 @@
+module SpringCollab2020StaticPuffer
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SpringCollab2020/StaticPuffer" StaticPuffer(x::Integer, y::Integer, right::Bool=false)
+
+const placements = Ahorn.PlacementDict(
+    "Static Puffer (Right) (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        StaticPuffer,
+        "point",
+        Dict{String, Any}(
+            "right" => true
+        )
+    ),
+    "Static Puffer (Left) (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        StaticPuffer,
+        "point",
+        Dict{String, Any}(
+            "right" => false
+        )
+    )    
+)
+
+sprite = "objects/puffer/idle00"
+
+function Ahorn.selection(entity::StaticPuffer)
+    x, y = Ahorn.position(entity)
+    scaleX = get(entity, "right", false) ? 1 : -1
+
+    return Ahorn.getSpriteRectangle(sprite, x, y, sx=scaleX)
+end
+
+function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::StaticPuffer, room::Maple.Room)
+    scaleX = get(entity, "right", false) ? 1 : -1
+
+    Ahorn.drawSprite(ctx, sprite, 0, 0, sx=scaleX)
+end
+
+end

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -308,3 +308,6 @@ placements.triggers.SpringCollab2020/SpeedBasedMusicParamTrigger.tooltips.paramN
 placements.triggers.SpringCollab2020/SpeedBasedMusicParamTrigger.tooltips.minSpeed=The minimum value the music parameter can take.
 placements.triggers.SpringCollab2020/SpeedBasedMusicParamTrigger.tooltips.maxSpeed=The maximum value the music parameter can take.
 placements.triggers.SpringCollab2020/SpeedBasedMusicParamTrigger.tooltips.activate=If ticked, the trigger will start adjusting the music parameter to match the player's speed.\nIf unticked, the trigger will stop adjusting that music parameter, and set it to minSpeed.
+
+# Static Puffer
+placements.entities.SpringCollab2020/StaticPuffer.tooltips.right=The initial direction of the puffer.

--- a/Entities/StaticPuffer.cs
+++ b/Entities/StaticPuffer.cs
@@ -1,0 +1,43 @@
+﻿using Celeste.Mod.Entities;
+using Monocle;
+using Microsoft.Xna.Framework;
+using MonoMod.Cil;
+using System;
+using Mono.Cecil.Cil;
+using System.Reflection;
+
+namespace Celeste.Mod.SpringCollab2020.Entities {
+    [CustomEntity("SpringCollab2020/StaticPuffer")]
+    class StaticPuffer : Puffer {
+        public static void Load() {
+            IL.Celeste.Puffer.ctor_Vector2_bool += onPufferConstructor;
+        }
+
+        public static void Unload() {
+            IL.Celeste.Puffer.ctor_Vector2_bool -= onPufferConstructor;
+        }
+
+        private static void onPufferConstructor(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+
+            while (cursor.TryGotoNext(MoveType.After, instr => instr.MatchCallvirt<SineWave>("Randomize"))) {
+                Logger.Log("SpringCollab2020/StaticPuffer", $"Injecting call to unrandomize puffer sine wave at {cursor.Index} in IL for Puffer constructor");
+
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.Emit(OpCodes.Ldfld, typeof(Puffer).GetField("idleSine", BindingFlags.NonPublic | BindingFlags.Instance));
+                cursor.EmitDelegate<Action<Puffer, SineWave>>((self, idleSine) => {
+                    if (self is StaticPuffer) {
+                        // unrandomize the initial pufferfish position.
+                        idleSine.Reset();
+                    }
+                });
+            }
+        }
+
+        public StaticPuffer(EntityData data, Vector2 offset) : base(data, offset) {
+            // remove the sine wave component so that it isn't updated.
+            Get<SineWave>()?.RemoveSelf();
+        }
+    }
+}

--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -37,6 +37,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             CameraCatchupSpeedTrigger.Load();
             ColorGradeFadeTrigger.Load();
             SpeedBasedMusicParamTrigger.Load();
+            StaticPuffer.Load();
             Everest.Events.Level.OnLoadBackdrop += onLoadBackdrop;
 
             DecalRegistry.AddPropertyHandler("scale", (decal, attrs) => {
@@ -79,6 +80,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             CameraCatchupSpeedTrigger.Unload();
             ColorGradeFadeTrigger.Unload();
             SpeedBasedMusicParamTrigger.Unload();
+            StaticPuffer.Unload();
             Everest.Events.Level.OnLoadBackdrop -= onLoadBackdrop;
         }
 


### PR DESCRIPTION
Just a puffer fish, except it doesn't wave around. Requested for a heart side.

The IL hook resets the sine wave just after it is randomized, because its value is used right after in the constructor. This way, the static position of the puffer is the one chosen in Ahorn. Then, the StaticPuffer constructor removes the SineWave component from the entity, so the wave stays at 0 all the time and the puffer doesn't move.