### PR TITLE
Leave Theo Behind Trigger

### DIFF
--- a/Ahorn/triggers/leaveTheoBehindTrigger.jl
+++ b/Ahorn/triggers/leaveTheoBehindTrigger.jl
@@ -1,0 +1,15 @@
+module SpringCollab2020LeaveTheoBehindTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/LeaveTheoBehindTrigger" LeaveTheoBehindTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
+    enable::Bool=false)
+
+const placements = Ahorn.PlacementDict(
+    "Leave Theo Behind (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        LeaveTheoBehindTrigger,
+        "rectangle",
+    ),
+)
+
+end

--- a/Ahorn/triggers/leaveTheoBehindTrigger.jl
+++ b/Ahorn/triggers/leaveTheoBehindTrigger.jl
@@ -2,8 +2,7 @@ module SpringCollab2020LeaveTheoBehindTrigger
 
 using ..Ahorn, Maple
 
-@mapdef Trigger "SpringCollab2020/LeaveTheoBehindTrigger" LeaveTheoBehindTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
-    enable::Bool=false)
+@mapdef Trigger "SpringCollab2020/LeaveTheoBehindTrigger" LeaveTheoBehindTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight)
 
 const placements = Ahorn.PlacementDict(
     "Leave Theo Behind (Spring Collab 2020)" => Ahorn.EntityPlacement(

--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -37,6 +37,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             CameraCatchupSpeedTrigger.Load();
             ColorGradeFadeTrigger.Load();
             SpeedBasedMusicParamTrigger.Load();
+            LeaveTheoBehindTrigger.Load();
             Everest.Events.Level.OnLoadBackdrop += onLoadBackdrop;
 
             DecalRegistry.AddPropertyHandler("scale", (decal, attrs) => {
@@ -79,6 +80,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             CameraCatchupSpeedTrigger.Unload();
             ColorGradeFadeTrigger.Unload();
             SpeedBasedMusicParamTrigger.Unload();
+            LeaveTheoBehindTrigger.Unload();
             Everest.Events.Level.OnLoadBackdrop -= onLoadBackdrop;
         }
 

--- a/Triggers/LeaveTheoBehindTrigger.cs
+++ b/Triggers/LeaveTheoBehindTrigger.cs
@@ -1,0 +1,69 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.Cil;
+using System;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+    [CustomEntity("SpringCollab2020/LeaveTheoBehindTrigger")]
+    class LeaveTheoBehindTrigger : Trigger {
+        private static bool leaveTheoBehind = false;
+
+        public static void Load() {
+            IL.Celeste.Level.EnforceBounds += onLevelEnforceBounds;
+            On.Celeste.Level.TransitionTo += onLevelTransitionTo;
+        }
+
+        public static void Unload() {
+            IL.Celeste.Level.EnforceBounds -= onLevelEnforceBounds;
+            On.Celeste.Level.TransitionTo -= onLevelTransitionTo;
+        }
+
+        private static void onLevelEnforceBounds(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+
+            while (cursor.TryGotoNext(MoveType.After, instr => instr.MatchCallvirt<Tracker>("GetEntity"))) {
+                // the only usage of GetEntity gets the TheoCrystal entity on the screen.
+                Logger.Log("SpringCollab2020/LeaveTheoBehindTrigger", $"Adding hook to leave Theo behind at {cursor.Index} in IL for Level.EnforceBounds");
+                cursor.EmitDelegate<Func<TheoCrystal, TheoCrystal>>(theo => {
+                    if (leaveTheoBehind) {
+                        return null; // pretend there is no Theo, so we can exit the room.
+                    }
+                    return theo;
+                });
+            }
+        }
+
+        private static void onLevelTransitionTo(On.Celeste.Level.orig_TransitionTo orig, Level self, LevelData next, Vector2 direction) {
+            if (leaveTheoBehind) {
+                // freeze all Theo Crystals that the player isn't carrying, to prevent them from crashing the game or being weird.
+                Player player = self.Tracker.GetEntity<Player>();
+                foreach (TheoCrystal crystal in self.Tracker.GetEntities<TheoCrystal>()) {
+                    if (player?.Holding?.Entity != crystal) {
+                        crystal.RemoveTag(Tags.TransitionUpdate);
+                    }
+                }
+            }
+
+            orig(self, next, direction);
+        }
+
+
+        public LeaveTheoBehindTrigger(EntityData data, Vector2 offset) : base(data, offset) { }
+
+        public override void OnEnter(Player player) {
+            base.OnEnter(player);
+            leaveTheoBehind = true;
+        }
+
+        public override void Removed(Scene scene) {
+            base.Removed(scene);
+            leaveTheoBehind = false;
+        }
+
+        public override void SceneEnd(Scene scene) {
+            base.SceneEnd(scene);
+            leaveTheoBehind = false;
+        }
+    }
+}


### PR DESCRIPTION
This is a trigger to enable leaving Theo behind when leaving the current room, to be used in a heart side.

It's kind of a bootleg of [Disposable Theo Trigger](https://gamebanana.com/gamefiles/11138), except it's implemented quite differently, and doesn't show up in Mod Options.

Issues related to TASing were reported with Disposable Theo enabled: there is a 1 frame timing difference in screen transitions desyncing TASes when the mod is on. Since having a dependency for a single trigger used once in the collab seems like a shame, I decided to reimplement it in the collab helper: the implementation is vastly different, but the overall behavior of the trigger is the same.