### PR TITLE
Pause Badeline Bosses Trigger

### DIFF
--- a/Ahorn/triggers/pauseBadelineBossesTrigger.jl
+++ b/Ahorn/triggers/pauseBadelineBossesTrigger.jl
@@ -1,0 +1,14 @@
+module SpringCollab2020PauseBadelineBossesTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/PauseBadelineBossesTrigger" PauseBadelineBossesTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight)
+
+const placements = Ahorn.PlacementDict(
+    "Pause Badeline Bosses (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        PauseBadelineBossesTrigger,
+        "rectangle",
+    ),
+)
+
+end

--- a/Triggers/PauseBadelineBossesTrigger.cs
+++ b/Triggers/PauseBadelineBossesTrigger.cs
@@ -1,0 +1,36 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.Utils;
+using System.Linq;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+    [CustomEntity("SpringCollab2020/PauseBadelineBossesTrigger")]
+    class PauseBadelineBossesTrigger : Trigger {
+        public PauseBadelineBossesTrigger(EntityData data, Vector2 offset) : base(data, offset) { }
+
+        public override void OnStay(Player player) {
+            base.OnStay(player);
+
+            // kick the attack coroutines from Badeline bosses so that they don't attack anymore.
+            foreach (FinalBoss badelineBoss in Scene.Tracker.GetEntities<FinalBoss>()) {
+                DynData<FinalBoss> bossData = new DynData<FinalBoss>(badelineBoss);
+                if (badelineBoss.Sprite.CurrentAnimationID == "idle") {
+                    badelineBoss.Remove(bossData.Get<Coroutine>("attackCoroutine"));
+                }
+            }
+        }
+
+        public override void OnLeave(Player player) {
+            base.OnLeave(player);
+
+            // add the attack coroutines back.
+            foreach (FinalBoss badelineBoss in Scene.Tracker.GetEntities<FinalBoss>()) {
+                Coroutine attackCoroutine = new DynData<FinalBoss>(badelineBoss).Get<Coroutine>("attackCoroutine");
+                if (!badelineBoss.Components.Contains(attackCoroutine)) {
+                    badelineBoss.Add(attackCoroutine);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This trigger prevents Badeline from attacking the player while they are inside it.

This works by removing the attackCoroutine from the Badeline bosses for the duration the player is in the trigger. Before removing the routine, the trigger waits for Badeline to be idle, because we don't want to interrupt it mid-attack.