### PR TITLE
Option to display grouped trigger spikes behind move blocks

### DIFF
--- a/Ahorn/entities/groupedTriggerSpikes.jl
+++ b/Ahorn/entities/groupedTriggerSpikes.jl
@@ -2,10 +2,10 @@ module SpringCollab2020GroupedTriggerSpikes
 
 using ..Ahorn, Maple
 
-@mapdef Entity "SpringCollab2020/GroupedTriggerSpikesUp" GroupedTriggerSpikesUp(x::Integer, y::Integer, width::Integer=Maple.defaultSpikeWidth, type::String="default")
-@mapdef Entity "SpringCollab2020/GroupedTriggerSpikesDown" GroupedTriggerSpikesDown(x::Integer, y::Integer, width::Integer=Maple.defaultSpikeWidth, type::String="default")
-@mapdef Entity "SpringCollab2020/GroupedTriggerSpikesLeft" GroupedTriggerSpikesLeft(x::Integer, y::Integer, height::Integer=Maple.defaultSpikeHeight, type::String="default")
-@mapdef Entity "SpringCollab2020/GroupedTriggerSpikesRight" GroupedTriggerSpikesRight(x::Integer, y::Integer, height::Integer=Maple.defaultSpikeHeight, type::String="default")
+@mapdef Entity "SpringCollab2020/GroupedTriggerSpikesUp" GroupedTriggerSpikesUp(x::Integer, y::Integer, width::Integer=Maple.defaultSpikeWidth, type::String="default", behindMoveBlocks::Bool=false)
+@mapdef Entity "SpringCollab2020/GroupedTriggerSpikesDown" GroupedTriggerSpikesDown(x::Integer, y::Integer, width::Integer=Maple.defaultSpikeWidth, type::String="default", behindMoveBlocks::Bool=false)
+@mapdef Entity "SpringCollab2020/GroupedTriggerSpikesLeft" GroupedTriggerSpikesLeft(x::Integer, y::Integer, height::Integer=Maple.defaultSpikeHeight, type::String="default", behindMoveBlocks::Bool=false)
+@mapdef Entity "SpringCollab2020/GroupedTriggerSpikesRight" GroupedTriggerSpikesRight(x::Integer, y::Integer, height::Integer=Maple.defaultSpikeHeight, type::String="default", behindMoveBlocks::Bool=false)
 
 const placements = Ahorn.PlacementDict()
 

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -155,10 +155,10 @@ placements.entities.SpringCollab2020/GroupedTriggerSpikesUp.tooltips.type=Change
 placements.entities.SpringCollab2020/GroupedTriggerSpikesDown.tooltips.type=Changes the visual appearance of the spikes.
 placements.entities.SpringCollab2020/GroupedTriggerSpikesLeft.tooltips.type=Changes the visual appearance of the spikes.
 placements.entities.SpringCollab2020/GroupedTriggerSpikesRight.tooltips.type=Changes the visual appearance of the spikes.
-placements.entities.SpringCollab2020/GroupedTriggerSpikesUp.tooltips.behindMoveBlocks=Whether the spikes should be deeper than normal in order to appear behind move blocks.
-placements.entities.SpringCollab2020/GroupedTriggerSpikesDown.tooltips.behindMoveBlocks=Whether the spikes should be deeper than normal in order to appear behind move blocks.
-placements.entities.SpringCollab2020/GroupedTriggerSpikesLeft.tooltips.behindMoveBlocks=Whether the spikes should be deeper than normal in order to appear behind move blocks.
-placements.entities.SpringCollab2020/GroupedTriggerSpikesRight.tooltips.behindMoveBlocks=Whether the spikes should be deeper than normal in order to appear behind move blocks.
+placements.entities.SpringCollab2020/GroupedTriggerSpikesUp.tooltips.behindMoveBlocks=Determines whether the trigger spikes appear behind move blocks.
+placements.entities.SpringCollab2020/GroupedTriggerSpikesDown.tooltips.behindMoveBlocks=Determines whether the trigger spikes appear behind move blocks.
+placements.entities.SpringCollab2020/GroupedTriggerSpikesLeft.tooltips.behindMoveBlocks=Determines whether the trigger spikes appear behind move blocks.
+placements.entities.SpringCollab2020/GroupedTriggerSpikesRight.tooltips.behindMoveBlocks=Determines whether the trigger spikes appear behind move blocks.
 
 # Move Block with Customizable Speed
 placements.entities.SpringCollab2020/MoveBlockCustomSpeed.tooltips.canSteer=Determines whether the move block can be moved by the player.

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -155,6 +155,10 @@ placements.entities.SpringCollab2020/GroupedTriggerSpikesUp.tooltips.type=Change
 placements.entities.SpringCollab2020/GroupedTriggerSpikesDown.tooltips.type=Changes the visual appearance of the spikes.
 placements.entities.SpringCollab2020/GroupedTriggerSpikesLeft.tooltips.type=Changes the visual appearance of the spikes.
 placements.entities.SpringCollab2020/GroupedTriggerSpikesRight.tooltips.type=Changes the visual appearance of the spikes.
+placements.entities.SpringCollab2020/GroupedTriggerSpikesUp.tooltips.behindMoveBlocks=Whether the spikes should be deeper than normal in order to appear behind move blocks.
+placements.entities.SpringCollab2020/GroupedTriggerSpikesDown.tooltips.behindMoveBlocks=Whether the spikes should be deeper than normal in order to appear behind move blocks.
+placements.entities.SpringCollab2020/GroupedTriggerSpikesLeft.tooltips.behindMoveBlocks=Whether the spikes should be deeper than normal in order to appear behind move blocks.
+placements.entities.SpringCollab2020/GroupedTriggerSpikesRight.tooltips.behindMoveBlocks=Whether the spikes should be deeper than normal in order to appear behind move blocks.
 
 # Move Block with Customizable Speed
 placements.entities.SpringCollab2020/MoveBlockCustomSpeed.tooltips.canSteer=Determines whether the move block can be moved by the player.

--- a/Entities/GroupedTriggerSpikes.cs
+++ b/Entities/GroupedTriggerSpikes.cs
@@ -47,10 +47,10 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
         private bool blockingLedge = false;
 
         public GroupedTriggerSpikes(EntityData data, Vector2 offset, Directions dir)
-            : this(data.Position + offset, GetSize(data, dir), dir, data.Attr("type", "default")) {
+            : this(data.Position + offset, GetSize(data, dir), dir, data.Attr("type", "default"), data.Bool("behindMoveBlocks", false)) {
         }
 
-        public GroupedTriggerSpikes(Vector2 position, int size, Directions direction, string overrideType)
+        public GroupedTriggerSpikes(Vector2 position, int size, Directions direction, string overrideType, bool behindMoveBlocks)
             : base(position) {
 
             this.size = size;
@@ -95,7 +95,11 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
                 JumpThruChecker = IsRiding
             });
 
-            Depth = -50;
+            if (behindMoveBlocks) {
+                Depth = 0; // move blocks have Depth = -1.
+            } else {
+                Depth = -50;
+            }
         }
 
         public override void Added(Scene scene) {


### PR DESCRIPTION
This was requested on Discord, because it just looks weird.

![image](https://cdn.discordapp.com/attachments/663508177181999136/711333175061643264/unknown.png)