### PR TITLE
Variable Crumble Block: fix the 'texture' attribute + add 'respawn time' attribute

### DIFF
--- a/Ahorn/entities/variableCrumble.jl
+++ b/Ahorn/entities/variableCrumble.jl
@@ -2,7 +2,8 @@ module SpringCollab2020VariableCrumbleBlock
 
 using ..Ahorn, Maple
 
-@mapdef Entity "SpringCollab2020/variableCrumbleBlock" VariableCrumbleBlock(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, texture::String="default", timer::Number=0.4)
+@mapdef Entity "SpringCollab2020/variableCrumbleBlock" VariableCrumbleBlock(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, texture::String="default",
+    timer::Number=0.4, respawnTimer::Number=2.0)
 
 const placements = Ahorn.PlacementDict(
     "Variable Crumble Blocks ($(uppercasefirst(texture))) (Spring Collab 2020)" => Ahorn.EntityPlacement(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -35,6 +35,7 @@ placements.triggers.SpringCollab2020/LightningStrikeTrigger.tooltips.constant=If
 # Variable Crumble Blocks
 placements.entities.SpringCollab2020/variableCrumbleBlock.tooltips.texture=The texture of the blocks that are crumbling.2
 placements.entities.SpringCollab2020/variableCrumbleBlock.tooltips.timer=How long the blocks will shake for before falling.
+placements.entities.SpringCollab2020/variableCrumbleBlock.tooltips.respawnTimer=How much time (in seconds) the block will take before respawning.
 
 # Floatier Space Block
 placements.entities.SpringCollab2020/floatierSpaceBlock.tooltips.disableSpawnOffset=Whether or not the entity should spawn without the random offset.

--- a/Entities/VariableCrumbleBlock.cs
+++ b/Entities/VariableCrumbleBlock.cs
@@ -26,23 +26,27 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
 
         public float crumbleTime = 0.4f;
 
-        public string OverrideTexture;
+        public float respawnTime = 2f;
 
-        public VariableCrumblePlatform(Vector2 position, float width, float timer)
+        private string overrideTexture;
+
+        public VariableCrumblePlatform(Vector2 position, float width, string overrideTexture, float timer, float respawnTimer)
             : base(position, width, 8f, false) {
             EnableAssistModeChecks = false;
+            this.overrideTexture = overrideTexture;
             crumbleTime = timer;
+            respawnTime = respawnTimer;
         }
 
         public VariableCrumblePlatform(EntityData data, Vector2 offset)
-            : this(data.Position + offset, (float) data.Width, data.Float("timer", 0.4f)) {
+            : this(data.Position + offset, (float) data.Width, data.Attr("texture"), data.Float("timer", 0.4f), data.Float("respawnTimer", 2f)) {
         }
 
         public override void Added(Scene scene) {
             AreaData areaData = AreaData.Get(scene);
             string crumbleBlock = areaData.CrumbleBlock;
-            if (OverrideTexture != null) {
-                areaData.CrumbleBlock = OverrideTexture;
+            if (overrideTexture != null) {
+                areaData.CrumbleBlock = overrideTexture;
             }
             base.Added(scene);
             MTexture mTexture = GFX.Game["objects/crumbleBlock/outline"];
@@ -142,7 +146,7 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
                         }
                     }
                 }
-                yield return 2f;
+                yield return respawnTime;
                 while (CollideCheck<Actor>() || CollideCheck<Solid>()) {
                     yield return null;
                 }


### PR DESCRIPTION
- The "texture" attribute was not applied at all. I checked all collab maps and changed the "cliffside" crumble blocks to "default" ones so that their look does not change. Only 1 map was impacted (Tortoise's) and the author agreed with this.
- Added a respawnTimer attribute, so that a dependency on Max Helping Hand for _that one_ attribute isn't required.