### PR TITLE
Badeline Bounce Direction Trigger

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -320,3 +320,6 @@ placements.entities.SpringCollab2020/ForegroundReflectionTentacles.tooltips.fear
 
 # Static Puffer
 placements.entities.SpringCollab2020/StaticPuffer.tooltips.right=The initial direction of the puffer.
+
+# Badeline Bounce Direction Trigger
+placements.triggers.SpringCollab2020/BadelineBounceDirectionTrigger.tooltips.bounceLeft=Determines the bounce direction of the player when hitting the Badeline Boss inside of the trigger (checked = to the left, unchecked = to the right).

--- a/Ahorn/triggers/badelineBounceDirectionTrigger.jl
+++ b/Ahorn/triggers/badelineBounceDirectionTrigger.jl
@@ -1,0 +1,15 @@
+module SpringCollab2020BadelineBounceDirectionTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SpringCollab2020/BadelineBounceDirectionTrigger" BadelineBounceDirectionTrigger(x::Integer, y::Integer,
+    width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight, bounceLeft::Bool=false)
+
+const placements = Ahorn.PlacementDict(
+    "Badeline Bounce Direction (Spring Collab 2020)" => Ahorn.EntityPlacement(
+        BadelineBounceDirectionTrigger,
+        "rectangle",
+    ),
+)
+
+end

--- a/SpringCollab2020Module.cs
+++ b/SpringCollab2020Module.cs
@@ -39,6 +39,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             SpeedBasedMusicParamTrigger.Load();
             StaticPuffer.Load();
             LeaveTheoBehindTrigger.Load();
+            BadelineBounceDirectionTrigger.Load();
             Everest.Events.Level.OnLoadBackdrop += onLoadBackdrop;
 
             DecalRegistry.AddPropertyHandler("scale", (decal, attrs) => {
@@ -83,6 +84,7 @@ namespace Celeste.Mod.SpringCollab2020 {
             SpeedBasedMusicParamTrigger.Unload();
             StaticPuffer.Unload();
             LeaveTheoBehindTrigger.Unload();
+            BadelineBounceDirectionTrigger.Unload();
             Everest.Events.Level.OnLoadBackdrop -= onLoadBackdrop;
         }
 

--- a/Triggers/BadelineBounceDirectionTrigger.cs
+++ b/Triggers/BadelineBounceDirectionTrigger.cs
@@ -1,0 +1,33 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+
+namespace Celeste.Mod.SpringCollab2020.Triggers {
+    [CustomEntity("SpringCollab2020/BadelineBounceDirectionTrigger")]
+    [Tracked]
+    class BadelineBounceDirectionTrigger : Trigger {
+        public static void Load() {
+            On.Celeste.Player.FinalBossPushLaunch += onPlayerBadelinePushLaunch;
+        }
+
+        public static void Unload() {
+            On.Celeste.Player.FinalBossPushLaunch -= onPlayerBadelinePushLaunch;
+        }
+
+        private static void onPlayerBadelinePushLaunch(On.Celeste.Player.orig_FinalBossPushLaunch orig, Player self, int dir) {
+            // if the player is inside a Badeline Bounce Direction Trigger, mod the bounce direction to be the one we want.
+            BadelineBounceDirectionTrigger trigger = self.CollideFirst<BadelineBounceDirectionTrigger>();
+            if (trigger != null) {
+                dir = trigger.bounceLeft ? -1 : 1;
+            }
+
+            orig(self, dir);
+        }
+
+        private bool bounceLeft;
+
+        public BadelineBounceDirectionTrigger(EntityData data, Vector2 offset) : base(data, offset) {
+            bounceLeft = data.Bool("bounceLeft");
+        }
+    }
+}


### PR DESCRIPTION
This is a simple trigger you place over a Badeline boss node to determine if Madeline gets pushed to the right or to the left when hitting Badeline.