### PR TITLE
Fixed a rendering issue with motion smoothing

### DIFF
--- a/Entities/CrystalBombDetonatorRenderer.cs
+++ b/Entities/CrystalBombDetonatorRenderer.cs
@@ -136,7 +136,7 @@ namespace Celeste.Mod.SpringCollab2020.Entities {
                     Vector2 vector = edge.Parent.Position + edge.B;
                     for (int num = 0; num <= edge.Length; num++) {
                         Vector2 vector2 = value + edge.Normal * num;
-                        Draw.Line(vector2, vector2 + edge.Perpendicular * edge.Wave[num], Color.Purple);
+                        Draw.Line(vector2, Calc.Round(vector2 + edge.Perpendicular * edge.Wave[num]), Color.Purple);
                     }
                 }
             }


### PR DESCRIPTION
This fixes an issue where the bloom of `CrystalBombDetonator`s is rendered at high res while in Motion Smoothing's Fancy mode